### PR TITLE
Response model fix

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -107,6 +107,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.16.1"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3-nullsafety.1"
   matcher:
     dependency: transitive
     description:
@@ -120,7 +127,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.4"
   path:
     dependency: transitive
     description:
@@ -244,7 +251,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
@@ -309,5 +316,5 @@ packages:
     source: hosted
     version: "0.1.2"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.10.0-110 <=2.11.0-213.1.beta"
   flutter: ">=1.17.0 <2.0.0"

--- a/lib/src/interface/IResponseModel.dart
+++ b/lib/src/interface/IResponseModel.dart
@@ -3,4 +3,6 @@ import 'IErrorModel.dart';
 abstract class IResponseModel<T> {
   T data;
   IErrorModel error;
+
+  IResponseModel(this.data, this.error);
 }

--- a/lib/src/model/response_model.dart
+++ b/lib/src/model/response_model.dart
@@ -1,9 +1,6 @@
-import '../interface/IErrorModel.dart';
 import '../interface/IResponseModel.dart';
 
 class ResponseModel<T> extends IResponseModel<T> {
-  T data;
-  IErrorModel error;
 
-  ResponseModel({this.data, this.error});
+  ResponseModel({data, error}) : super(data, error);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,7 +197,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.2"
+    version: "0.6.3-nullsafety.1"
   logging:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.4"
   mockito:
     dependency: "direct dev"
     description:
@@ -398,7 +398,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0-nullsafety.2"
   stream_channel:
     dependency: transitive
     description:
@@ -470,5 +470,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0 <2.11.0"
+  dart: ">=2.10.0 <=2.11.0-213.1.beta"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
Because ResponseModel and IResponseModel have same fields, a ResponseModel object has data and error fields twice.
![2020-12-30 10_21_15-Window](https://user-images.githubusercontent.com/33382864/103336719-0c770100-4a8a-11eb-894a-c6ca4a83a644.png)
![2020-12-30 10_27_40-Window](https://user-images.githubusercontent.com/33382864/103336717-0bde6a80-4a8a-11eb-9713-1ed994ae0aa1.png)