### PR TITLE
JSON body parser conflict 

### DIFF
--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -214,6 +214,9 @@ class NetworkManager with dio.DioMixin implements dio.Dio, INetworkManager {
     ErrorModel();
     if (errorModel == null) {
       error.response = data;
+    } else if (data.runtimeType.toString() == '_InternalLinkedHashMap<String, dynamic>' ||
+        data.runtimeType.toString() == 'Map<String, dynamic>') {
+      error.model = errorModel?.fromJson(data);
     } else {
       error.model = errorModel?.fromJson(jsonDecode(data));
     }

--- a/lib/src/operation/network_model_parser.dart
+++ b/lib/src/operation/network_model_parser.dart
@@ -5,7 +5,13 @@ extension _CoreServiceExtension on NetworkManager {
     if (data is INetworkModel) {
       return data.toJson();
     } else if (data != null) {
-      return jsonEncode(data);
+      if (data.runtimeType.toString() ==
+              '_InternalLinkedHashMap<String, dynamic>' ||
+          data.runtimeType.toString() == 'Map<String, dynamic>') {
+        return data;
+      } else {
+        return jsonEncode(data);
+      }
     } else {
       return data;
     }


### PR DESCRIPTION
### Problem
Vexana has a really weird behavior. Such that, when the response is successful, body-parser requires **unencoded** JSON to decode and resolve. But when it comes to error response parsing, It requires **encoded** JSON to resolve. It means that if it receives **unencoded** JSON response then vexana error parser will throw an error that causes an empty error model and that means you can not understand what kind of error did server return ... 

### Solution
So, I think vexana should have capabilities for both **encoded or unencoded** cases for both **data model** parsing and **error model** parsing.

I have provided a very simple and short fix if you wish to accept.

Also you can check out what I mean by **encoding** for an HTTP JSON response;

> encoded: {"code":"U1", "message":"Wrong credentials"}
> unencoded: '{"code":"U1", "message":"Wrong credentials"}'