### PR TITLE
updated response model to return error message if parsed model is null

### DIFF
--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -313,7 +313,12 @@ class NetworkManager<E extends INetworkModel<E>?>
   ) {
     final model = _parseBody<R, T>(data, parserModel);
 
-    return ResponseModel<R, E>(data: model);
+    return ResponseModel<R, E>(
+      data: model,
+      error: model == null
+          ? ErrorModel(description: 'Null is returned after parsing a model $T')
+          : null,
+    );
   }
 
   ResponseModel<R, E> _onError<R>(dio.DioException e) {

--- a/lib/src/operation/network_model_parser.dart
+++ b/lib/src/operation/network_model_parser.dart
@@ -46,6 +46,10 @@ extension _CoreServiceExtension on NetworkManager {
   ///   The method returns an object of type R.
   R? _parseBody<R, T extends INetworkModel>(dynamic responseBody, T model) {
     try {
+      if (R is EmptyModel || R == EmptyModel) {
+        return EmptyModel(name: responseBody.toString()) as R;
+      }
+
       if (responseBody is List) {
         return responseBody
             .map(
@@ -53,18 +57,14 @@ extension _CoreServiceExtension on NetworkManager {
             )
             .cast<T>()
             .toList() as R;
-      } else if (responseBody is Map<String, dynamic>) {
+      }
+
+      if (responseBody is Map<String, dynamic>) {
         return model.fromJson(responseBody) as R;
       } else {
-        if (R is EmptyModel || R == EmptyModel) {
-          return EmptyModel(name: responseBody.toString()) as R;
-        } else {
-          CustomLogger(
-            isEnabled: isEnableLogger ?? false,
-            data: 'Be careful your data $responseBody, I could not parse it',
-          );
-          return null;
-        }
+        /// Throwing exception if the response body is not a List or a Map<String, dynamic>.
+        throw Exception(
+            'Response body is not a List or a Map<String, dynamic>');
       }
     } catch (e) {
       CustomLogger(

--- a/lib/src/operation/network_model_parser.dart
+++ b/lib/src/operation/network_model_parser.dart
@@ -17,10 +17,14 @@ extension _CoreServiceExtension on NetworkManager {
   /// type. It is used as input to determine the type of data and convert it accordingly.
   ///
   /// Returns:
-  ///   The method `_getBodyModel` returns a dynamic value. The specific value that is returned depends on
-  /// the type of the `data` parameter. If `data` is an instance of `IFormDataModel`, the method returns
-  /// the result of calling the `toFormData` method on `data`. If `data` is an instance of
-  /// `INetworkModel`, the method returns the result of calling the `
+  ///   The method `_getBodyModel` returns a dynamic value. The specific value
+  /// that is returned depends on the type of the `data` parameter.
+  ///  If `data` is an instance of `IFormDataModel`, the method returns
+  ///  the result of calling the `toFormData` method on `data`.
+  ///  If `data` is an instance of `INetworkModel`,
+  ///  the method returns the result of calling `toJson` method on `data`.
+  ///  If `data` is not null, the method returns the
+  ///  result of calling `jsonEncode` method on `data`.
   dynamic _getBodyModel(dynamic data) {
     if (data is IFormDataModel) {
       return data.toFormData();


### PR DESCRIPTION
### Case
I faced a problem in a project, where parsed model had wrong type, so the logger printed that it was waiting type of `int`but `String` is received. But in response model `error` and `data` were returned as `null`

```
      final response =
          await manager.send<ExampleModel, ExampleModel>(
              'anyExampleAPI',
              parseModel: ExampleModel(),
              method: RequestType.GET);
```
#### Expected result
- response.data is null
- response.error has a message
#### Actual result
- response.data is null
- response.error is null

### After update:
#### Expected result
- response.data is null
- response.error has a message
#### Actual result
- response.data is null
- response.error = `"Null is returned after parsing a model ExampleModel"`
