### PR TITLE
Refactor NetworkManagerErrorInterceptor to handle null onResponseParse

### DIFF
--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -47,12 +47,12 @@ mixin NetworkManagerErrorInterceptor {
             maxAttempts: NetworkManagerParameters.maxRetryCount,
             retryIf: _retryIf,
           );
-
-          return handler.resolve(
-            parameters.onResponseParse!(
-              response,
-            ),
-          );
+          // onResponseParse is null, then return response
+          if (parameters.onResponseParse == null) {
+            return handler.resolve(response);
+          }
+          // Call onResponseParse callback and return response
+          return handler.resolve(parameters.onResponseParse!(response));
         } catch (_) {
           /// cancel request & call onRefreshFail callback and unlock
           error.requestOptions.cancelToken?.cancel();


### PR DESCRIPTION
## Null check fix on `NetworkManagerErrorInterceptor`

- [x] bug report

## What is the current behavior?
The code calls the onResponseParse callback function from the parameters object without null check.

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
```
final class TempNetworkManager extends NetworkManager<EmptyModel> {
  TempNetworkManager()
      : super(
          options: BaseOptions(baseUrl: 'baseUrl'),
          onRefreshToken: (exception, _) async {
            final idToken = _getToken();
            exception.requestOptions.headers['Authorization'] = idToken;
            return exception;
          },
          // Below code not passed.
          // onReply: (response) => response,
        );

  static String _getToken() => 'Token';
```

## What is the expected behavior?

1. It checks if the `onResponseParse` callback in the parameters object is null.
2. If `onResponseParse` is `null`, it resolves the response using `handler.resolve(response)`.
3. if `onResponseParse` is `not null`, it calls the `onResponseParse` callback with the `response` and then resolves the response using `handler.resolve(parameters.onResponseParse!(response))`.