### PR TITLE
Refresh Token Dart Code example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,18 @@ Many projects use authentication structure for mobile security (like a jwt). It 
 > Since i locked all requests, I am giving a new service instance.
 
 ```dart
-INetworkManager  networkManager = NetworkManager(isEnableLogger: true, options: BaseOptions(baseUrl: "https://jsonplaceholder.typicode.com/"),
-onRefreshFail: () {  //Navigate to login },
- onRefreshToken: (error, newService) async {
-    <!-- Write your refresh token business -->
-    <!-- Then update error.req.headers to new token -->
-    return error;
-});
+INetworkManager  networkManager = NetworkManager(
+        isEnableLogger: true,
+        options: BaseOptions(baseUrl: "https://jsonplaceholder.typicode.com/"),
+        onRefreshFail: () {
+            //Navigate to login 
+        }, 
+        onRefreshToken: (error, newService) async {
+             <!-- Write your refresh token business -->
+             <!-- Then update error.req.headers to new token -->
+          return error;
+        }
+);
 ```
 
 ### **Caching** 🧲


### PR DESCRIPTION
### Refresh Token Dart Example update:
In the below screenshot `onRefreshToken` seems to be nested by `onRefreshFail`, so when a developer tries to implement it he might get confused.

#### - Screenshot
![Screenshot from 2024-08-07 23-14-20](https://github.com/user-attachments/assets/205ef0e7-38a4-4ea4-a802-10b3c170726c)
#### - End of screenshot

### Updated Version: `onRefreshFail` is not within `onRefreshToken`
#### - Screenshot
![Screenshot from 2024-08-07 23-14-00](https://github.com/user-attachments/assets/3c092ac7-7793-4c0c-8417-d17c60530e2f)
#### - End of screenshot