### PR TITLE
feat: add maxRetryCount param

### DIFF
--- a/lib/src/mixin/network_manager_core_operation.dart
+++ b/lib/src/mixin/network_manager_core_operation.dart
@@ -33,8 +33,7 @@ mixin NetworkManagerCoreOperation<E extends INetworkModel<E>> {
     CancelToken? cancelToken,
     bool? forceUpdateDecode,
   }) async {
-    if (!isErrorDialog ||
-        _noNetworkTryCount == NetworkManagerParameters.maxRetryCount) {
+    if (!isErrorDialog || _noNetworkTryCount == parameters.maxRetryCount) {
       return onError.call(error);
     }
 
@@ -89,8 +88,7 @@ mixin NetworkManagerCoreOperation<E extends INetworkModel<E>> {
     CancelToken? cancelToken,
     bool? forceUpdateDecode,
   }) async {
-    if (!isErrorDialog ||
-        _noNetworkTryCount == NetworkManagerParameters.maxRetryCount) {
+    if (!isErrorDialog || _noNetworkTryCount == parameters.maxRetryCount) {
       return onError.call(error);
     }
 

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -44,7 +44,7 @@ mixin NetworkManagerErrorInterceptor {
             () => _createNewRequest(error),
             onRetry: (_) async =>
                 error = await _createError(parameters, exception),
-            maxAttempts: NetworkManagerParameters.maxRetryCount,
+            maxAttempts: parameters.maxRetryCount,
             retryIf: _retryIf,
           );
           // onResponseParse is null, then return response
@@ -78,6 +78,7 @@ mixin NetworkManagerErrorInterceptor {
         isEnableLogger: params.isEnableLogger,
         isEnableTest: params.isEnableTest,
         options: parameters.baseOptions,
+        maxRetryCount: params.maxRetryCount,
       ),
     );
   }

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -16,8 +16,6 @@ typedef OnReply = Response<dynamic> Function(
 class NetworkManagerParameters extends Equatable {
   final VoidCallback? onRefreshFail;
 
-  static const int maxRetryCount = 3;
-
   final IFileManager? fileManager;
 
   final bool? isEnableTest;
@@ -38,6 +36,8 @@ class NetworkManagerParameters extends Equatable {
 
   final OnReply? onResponseParse;
 
+  final int maxRetryCount;
+
   const NetworkManagerParameters({
     required BaseOptions options,
     this.onRefreshFail,
@@ -50,6 +50,7 @@ class NetworkManagerParameters extends Equatable {
     this.interceptor,
     this.onRefreshToken,
     this.onResponseParse,
+    this.maxRetryCount = 3,
   }) : baseOptions = options;
 
   @override

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -42,6 +42,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     IFileManager? fileManager,
     Interceptor? interceptor,
     OnReply? onReply,
+    int maxRetryCount = 3,
   }) {
     parameters = NetworkManagerParameters(
       options: options,
@@ -54,6 +55,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
       onRefreshToken: onRefreshToken,
       onRefreshFail: onRefreshFail,
       onResponseParse: onReply,
+      maxRetryCount: maxRetryCount,
     );
     _setup();
   }

--- a/test/unit/common/mock_network_manager.dart
+++ b/test/unit/common/mock_network_manager.dart
@@ -18,6 +18,7 @@ final class MockErrorCustomNetworkManager extends NetworkManager<EmptyModel> {
       : super(
           options: BaseOptions(baseUrl: baseUrl),
           isEnableTest: true,
+          maxRetryCount: 5,
           onRefreshFail: () => print('onRefreshFail Triggered'),
           onRefreshToken: (e, networkManager) async {
             await onRefresh.call();

--- a/test/unit/network_manager_error_test.dart
+++ b/test/unit/network_manager_error_test.dart
@@ -22,7 +22,7 @@ void main() {
       method: RequestType.GET,
     );
     stopServer();
-    expect(retryCount, 3);
+    expect(retryCount, 5);
     expect(response.error?.statusCode, 401);
   });
 
@@ -57,7 +57,7 @@ void main() {
       ),
     ]);
     stopServer();
-    expect(retryCount, 3);
+    expect(retryCount, 5);
     expect(cancelToken.isCancelled, true);
   });
 


### PR DESCRIPTION
I noticed that `maxRetryCount` is not mutable, maybe it could be a useful improvement.

Tests were run before the Pull Request was opened and it was found that the enhancement did not cause any unforeseen problems:

<img width="260" alt="Ekran Resmi 2024-09-03 14 53 33" src="https://github.com/user-attachments/assets/d25b6d52-53cb-49ec-9cc6-654a96e75244">


