### PR TITLE
Fix Issue with Retrying Failed Request After Successful Token Refresh

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -395,7 +395,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.1.0"
+    version: "5.0.1"
   vm_service:
     dependency: transitive
     description:

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -53,10 +53,17 @@ mixin NetworkManagerErrorInterceptor {
           }
           // Call onResponseParse callback and return response
           return handler.resolve(parameters.onResponseParse!(response));
-        } catch (_) {
+        } catch (err) {
           /// cancel request & call onRefreshFail callback and unlock
           error.requestOptions.cancelToken?.cancel();
           parameters.onRefreshFail?.call();
+
+          /// If error is DioException, then return error
+          if (err is DioException) {
+            return handler.next(err);
+          }
+
+          /// If error is not DioException, then return error
           return handler.next(exception);
         }
       },


### PR DESCRIPTION
### **Problem:** 
In the application, after successfully obtaining a Refresh Token, a new request is automatically sent with the refreshed token. However, if a different error (such as 500 Internal Server Error) is encountered during this second request, instead of an authentication error (`401 Unauthorized`), the original authentication error from the first request is mistakenly thrown again. This prevents handling different errors correctly after the Refresh Token process.

### **Solution:**
This PR ensures that if a different error occurs during the second request after a successful token refresh, that error is properly caught and handled. If a new error is encountered, the original authentication error is not thrown again, and the new error is raised.

**Changes Made:**
1. **New Error Handling Added:** If a new error occurs during the request after the Refresh Token process, it is handled with `handler.next(err)`, and the previous error is not reused.
   
2. **Request Cancellation and Callback:** When an error occurs after the Refresh Token process, the request is canceled using `error.requestOptions.cancelToken?.cancel()` and the `onRefreshFail` callback is triggered. This ensures the user is informed about the failure of the Refresh Token process.

### **Code Example:**

```dart
} catch (err) {
  /// cancel request & call onRefreshFail callback and unlock
  error.requestOptions.cancelToken?.cancel();
  parameters.onRefreshFail?.call();

  /// If error is DioException, then return error
  if (err is DioException) {
    return handler.next(err);
  }

  /// If error is not DioException, then return the original error
  return handler.next(exception);
}
```

### **With This Change:**
- If a different error (other than 401 Unauthorized) occurs during the request after a successful token refresh, it is correctly handled and the original error is not reused.
- The `cancelToken` and `onRefreshFail` callbacks function correctly during error management and request cancellation.

### **Tested Scenarios:**
- Scenarios where requests succeed after a successful Refresh Token process.
- Scenarios where different errors are encountered after the Refresh Token process, and these errors are correctly handled.
- Scenarios where the `onRefreshFail` function is successfully triggered.


Fixes #118 
