### PR TITLE
remove flutter_lints and lints packages

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -395,7 +395,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.1"
+    version: "5.0.2"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -187,14 +187,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -245,14 +237,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  lints:
-    dependency: "direct dev"
-    description:
-      name: lints
-      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   logger:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,16 +34,13 @@ dependencies:
   shared_preferences: ^2.0.3
 
   # Utility
-  retry: ^3.1.2 
+  retry: ^3.1.2
   equatable: ^2.0.5
 
 dev_dependencies:
-  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  lints: ^4.0.0
   mockito: ^5.0.0
   path_provider_platform_interface: ^2.0.1
   plugin_platform_interface: ^2.0.0
   very_good_analysis: ^6.0.0
-


### PR DESCRIPTION
Removed [flutter_lints](https://pub.dev/packages/flutter_lints) and [lints](https://pub.dev/packages/lints) packages as [very_good_analysis](https://pub.dev/packages/very_good_analysis) is used as a linter tool