### PR TITLE
Optional Refresh Token Handling

### DIFF
--- a/example/.metadata
+++ b/example/.metadata
@@ -1,11 +1,11 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-  channel: master
+  revision: "dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668"
+  channel: "stable"
 
 project_type: app
 
@@ -13,26 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-    - platform: android
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-    - platform: ios
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-    - platform: linux
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
+      create_revision: dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668
+      base_revision: dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668
     - platform: macos
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-    - platform: web
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-    - platform: windows
-      create_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
-      base_revision: 4f034a40454b86064fdcb9dce156975c3fad0572
+      create_revision: dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668
+      base_revision: dec2ee5c1f98f8e84a7d5380c05eb8a3d0a81668
 
   # User provided section
 

--- a/example/lib/json_place_holder/json_place_holder_view_model.dart
+++ b/example/lib/json_place_holder/json_place_holder_view_model.dart
@@ -35,7 +35,7 @@ abstract class JsonPlaceHolderViewModel extends State<JsonPlaceHolder> {
     changeLoading();
     final response = await networkManager.send<Post, List<Post>>(
       '/posts',
-      parseModel: Post(),
+      parseModel: const Post(),
       method: RequestType.GET,
       isErrorDialog: true,
     );
@@ -51,11 +51,6 @@ abstract class JsonPlaceHolderViewModel extends State<JsonPlaceHolder> {
     setState(() {
       isLoading = !isLoading;
     });
-  }
-
-  //You can use this function for custom generate an error model.
-  INetworkModel<Post> _errorModelFromData(Map<String, dynamic> data) {
-    return Post.fromJson(data);
   }
 }
 

--- a/example/lib/json_place_holder/model/post.dart
+++ b/example/lib/json_place_holder/model/post.dart
@@ -1,19 +1,17 @@
 import 'package:vexana/vexana.dart';
 
 class Post extends INetworkModel<Post> {
-  int? userId;
-  int? id;
-  String? title;
-  String? body;
+  const Post({this.userId, this.id, this.title, this.body});
 
-  Post({this.userId, this.id, this.title, this.body});
-
-  Post.fromJson(Map<String, dynamic> json) {
-    userId = json['userId'];
-    id = json['id'];
-    title = json['title'];
-    body = json['body'];
-  }
+  Post.fromJson(Map<String, dynamic> json)
+      : userId = json['userId'] is int ? json['userId'] as int : null,
+        id = json['id'] is int ? json['id'] as int : null,
+        title = json['title'] is String ? json['title'] as String : null,
+        body = json['body'] is String ? json['body'] as String : null;
+  final int? userId;
+  final int? id;
+  final String? title;
+  final String? body;
 
   @override
   Map<String, dynamic> toJson() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
-import 'package:example/json_place_holder/json_place_holder.dart';
 import 'package:flutter/material.dart';
+
+import './json_place_holder/json_place_holder.dart';
 
 void main() => runApp(const MyApp());
 

--- a/example/macos/RunnerTests/RunnerTests.swift
+++ b/example/macos/RunnerTests/RunnerTests.swift
@@ -1,0 +1,12 @@
+import Cocoa
+import FlutterMacOS
+import XCTest
+
+class RunnerTests: XCTestCase {
+
+  func testExample() {
+    // If you add code to the Runner application, consider adding tests here.
+    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  }
+
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   dio:
     dependency: transitive
     description:
@@ -124,18 +124,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -324,7 +324,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -337,10 +337,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -395,15 +395,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.2"
+    version: "5.0.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -421,5 +421,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/lib/src/feature/adapter/web_adapter.dart
+++ b/lib/src/feature/adapter/web_adapter.dart
@@ -5,7 +5,6 @@ import 'package:dio/dio.dart';
 /// class, which implements the HttpClientAdapter
 /// interface.
 HttpClientAdapter createAdapter({bool isEnableTest = false}) {
-  final adapter = HttpClientAdapter() as BrowserHttpClientAdapter;
-  adapter.withCredentials = true;
-  return adapter;
+  return (HttpClientAdapter() as BrowserHttpClientAdapter)
+    ..withCredentials = true;
 }

--- a/lib/src/feature/adapter/web_adapter.dart
+++ b/lib/src/feature/adapter/web_adapter.dart
@@ -5,6 +5,5 @@ import 'package:dio/dio.dart';
 /// class, which implements the HttpClientAdapter
 /// interface.
 HttpClientAdapter createAdapter({bool isEnableTest = false}) {
-  return (HttpClientAdapter() as BrowserHttpClientAdapter)
-    ..withCredentials = true;
+  return BrowserHttpClientAdapter()..withCredentials = true;
 }

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -1,4 +1,5 @@
 import 'package:vexana/src/mixin/index.dart';
+import 'package:vexana/src/model/request_flag.dart';
 import 'package:vexana/vexana.dart';
 
 /// The `INetworkManager` interface is used to define the methods that are used
@@ -38,7 +39,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
-    bool? disableRefreshToken,
+    Set<RequestFlag>? requestFlags,
   });
 
   /// The sendRequest method is used to send an HTTP request
@@ -57,7 +58,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
-    bool? disableRefreshToken,
+    Set<RequestFlag>? requestFlags,
   });
 
   /// The `downloadFileSimple` method is used to download a file from a

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -1,5 +1,4 @@
 import 'package:vexana/src/mixin/index.dart';
-import 'package:vexana/src/model/request_flag.dart';
 import 'package:vexana/vexana.dart';
 
 /// The `INetworkManager` interface is used to define the methods that are used

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -38,6 +38,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
+    bool? handleRefreshToken,
   });
 
   /// The sendRequest method is used to send an HTTP request

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -38,7 +38,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
-    bool? handleRefreshToken,
+    bool? disableRefreshToken,
   });
 
   /// The sendRequest method is used to send an HTTP request
@@ -57,6 +57,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
+    bool? disableRefreshToken,
   });
 
   /// The `downloadFileSimple` method is used to download a file from a

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -31,8 +31,8 @@ mixin NetworkManagerErrorInterceptor {
           return handler.next(exception);
         }
 
-        /// If callback for onRefreshToken is null, then return error
-        if (parameters.onRefreshToken == null) {
+        /// If handleRefreshToken is false, then return error
+        if (!parameters.handleRefreshToken) {
           return handler.next(exception);
         }
 
@@ -86,6 +86,7 @@ mixin NetworkManagerErrorInterceptor {
         isEnableTest: params.isEnableTest,
         options: parameters.baseOptions,
         maxRetryCount: params.maxRetryCount,
+        handleRefreshToken: params.handleRefreshToken,
       ),
     );
   }

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -31,8 +31,10 @@ mixin NetworkManagerErrorInterceptor {
           return handler.next(exception);
         }
 
-        /// If handleRefreshToken is false, then return error
-        if (!parameters.handleRefreshToken) {
+        /// If handleRefreshToken is false or onRefreshToken is null,
+        /// then return error
+        if (!parameters.handleRefreshToken ||
+            parameters.onRefreshToken == null) {
           return handler.next(exception);
         }
 

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -31,10 +31,15 @@ mixin NetworkManagerErrorInterceptor {
           return handler.next(exception);
         }
 
-        /// If handleRefreshToken is false or onRefreshToken is null,
-        /// then return error
-        if (!parameters.handleRefreshToken ||
-            parameters.onRefreshToken == null) {
+        /// If callback for onRefreshToken is null, then return error
+        if (parameters.onRefreshToken == null) {
+          return handler.next(exception);
+        }
+
+        /// If disableRefreshToken is true, then return error
+        final disableRefreshToken =
+            exception.requestOptions.extra['disableRefreshToken'] == true;
+        if (disableRefreshToken) {
           return handler.next(exception);
         }
 
@@ -88,7 +93,6 @@ mixin NetworkManagerErrorInterceptor {
         isEnableTest: params.isEnableTest,
         options: parameters.baseOptions,
         maxRetryCount: params.maxRetryCount,
-        handleRefreshToken: params.handleRefreshToken,
       ),
     );
   }

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -2,6 +2,7 @@ import 'dart:io' if (dart.library.html) 'dart:html';
 
 import 'package:retry/retry.dart';
 import 'package:vexana/src/mixin/index.dart';
+import 'package:vexana/src/model/request_flag.dart';
 import 'package:vexana/vexana.dart';
 
 /// Network manager error interceptor
@@ -36,10 +37,11 @@ mixin NetworkManagerErrorInterceptor {
           return handler.next(exception);
         }
 
-        /// If disableRefreshToken is true, then return error
-        final disableRefreshToken =
-            exception.requestOptions.extra['disableRefreshToken'] == true;
-        if (disableRefreshToken) {
+        /// Check if refresh token is disabled via request flags
+        final requestFlags = RequestFlagExtension.fromExtraMap(
+          exception.requestOptions.extra,
+        );
+        if (requestFlags.shouldDisableRefreshToken) {
           return handler.next(exception);
         }
 

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -2,7 +2,6 @@ import 'dart:io' if (dart.library.html) 'dart:html';
 
 import 'package:retry/retry.dart';
 import 'package:vexana/src/mixin/index.dart';
-import 'package:vexana/src/model/request_flag.dart';
 import 'package:vexana/vexana.dart';
 
 /// Network manager error interceptor

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -54,11 +54,7 @@ class NetworkManagerParameters extends Equatable {
     this.onResponseParse,
     this.maxRetryCount = 3,
     bool? handleRefreshToken,
-  })  : assert(
-          handleRefreshToken != true || onRefreshToken != null,
-          'handleRefreshToken cannot be true if onRefreshToken is null',
-        ),
-        baseOptions = options,
+  })  : baseOptions = options,
         handleRefreshToken = handleRefreshToken ?? onRefreshToken != null;
 
   NetworkManagerParameters copyWith({

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -38,8 +38,6 @@ class NetworkManagerParameters extends Equatable {
 
   final int maxRetryCount;
 
-  final bool handleRefreshToken;
-
   const NetworkManagerParameters({
     required BaseOptions options,
     this.onRefreshFail,
@@ -53,9 +51,7 @@ class NetworkManagerParameters extends Equatable {
     this.onRefreshToken,
     this.onResponseParse,
     this.maxRetryCount = 3,
-    bool? handleRefreshToken,
-  })  : baseOptions = options,
-        handleRefreshToken = handleRefreshToken ?? onRefreshToken != null;
+  }) : baseOptions = options;
 
   NetworkManagerParameters copyWith({
     VoidCallback? onRefreshFail,
@@ -70,7 +66,6 @@ class NetworkManagerParameters extends Equatable {
     RefreshTokenCallBack? onRefreshToken,
     OnReply? onResponseParse,
     int? maxRetryCount,
-    bool? handleRefreshToken,
   }) {
     return NetworkManagerParameters(
       options: baseOptions ?? this.baseOptions,
@@ -86,10 +81,9 @@ class NetworkManagerParameters extends Equatable {
       onRefreshToken: onRefreshToken ?? this.onRefreshToken,
       onResponseParse: onResponseParse ?? this.onResponseParse,
       maxRetryCount: maxRetryCount ?? this.maxRetryCount,
-      handleRefreshToken: handleRefreshToken ?? this.handleRefreshToken,
     );
   }
 
   @override
-  List<Object> get props => [baseOptions, handleRefreshToken];
+  List<Object> get props => [baseOptions];
 }

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -53,37 +53,6 @@ class NetworkManagerParameters extends Equatable {
     this.maxRetryCount = 3,
   }) : baseOptions = options;
 
-  NetworkManagerParameters copyWith({
-    VoidCallback? onRefreshFail,
-    IFileManager? fileManager,
-    bool? isEnableTest,
-    bool? isEnableLogger,
-    NoNetwork? noNetwork,
-    int? noNetworkTryCount,
-    bool? skippingSSLCertificate,
-    Interceptor? interceptor,
-    BaseOptions? baseOptions,
-    RefreshTokenCallBack? onRefreshToken,
-    OnReply? onResponseParse,
-    int? maxRetryCount,
-  }) {
-    return NetworkManagerParameters(
-      options: baseOptions ?? this.baseOptions,
-      onRefreshFail: onRefreshFail ?? this.onRefreshFail,
-      fileManager: fileManager ?? this.fileManager,
-      isEnableTest: isEnableTest ?? this.isEnableTest,
-      isEnableLogger: isEnableLogger ?? this.isEnableLogger,
-      noNetwork: noNetwork ?? this.noNetwork,
-      noNetworkTryCount: noNetworkTryCount ?? this.noNetworkTryCount,
-      skippingSSLCertificate:
-          skippingSSLCertificate ?? this.skippingSSLCertificate,
-      interceptor: interceptor ?? this.interceptor,
-      onRefreshToken: onRefreshToken ?? this.onRefreshToken,
-      onResponseParse: onResponseParse ?? this.onResponseParse,
-      maxRetryCount: maxRetryCount ?? this.maxRetryCount,
-    );
-  }
-
   @override
   List<Object> get props => [baseOptions];
 }

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -38,6 +38,8 @@ class NetworkManagerParameters extends Equatable {
 
   final int maxRetryCount;
 
+  final bool handleRefreshToken;
+
   const NetworkManagerParameters({
     required BaseOptions options,
     this.onRefreshFail,
@@ -51,8 +53,47 @@ class NetworkManagerParameters extends Equatable {
     this.onRefreshToken,
     this.onResponseParse,
     this.maxRetryCount = 3,
-  }) : baseOptions = options;
+    bool? handleRefreshToken,
+  })  : assert(
+          handleRefreshToken != true || onRefreshToken != null,
+          'handleRefreshToken cannot be true if onRefreshToken is null',
+        ),
+        baseOptions = options,
+        handleRefreshToken = handleRefreshToken ?? onRefreshToken != null;
+
+  NetworkManagerParameters copyWith({
+    VoidCallback? onRefreshFail,
+    IFileManager? fileManager,
+    bool? isEnableTest,
+    bool? isEnableLogger,
+    NoNetwork? noNetwork,
+    int? noNetworkTryCount,
+    bool? skippingSSLCertificate,
+    Interceptor? interceptor,
+    BaseOptions? baseOptions,
+    RefreshTokenCallBack? onRefreshToken,
+    OnReply? onResponseParse,
+    int? maxRetryCount,
+    bool? handleRefreshToken,
+  }) {
+    return NetworkManagerParameters(
+      options: baseOptions ?? this.baseOptions,
+      onRefreshFail: onRefreshFail ?? this.onRefreshFail,
+      fileManager: fileManager ?? this.fileManager,
+      isEnableTest: isEnableTest ?? this.isEnableTest,
+      isEnableLogger: isEnableLogger ?? this.isEnableLogger,
+      noNetwork: noNetwork ?? this.noNetwork,
+      noNetworkTryCount: noNetworkTryCount ?? this.noNetworkTryCount,
+      skippingSSLCertificate:
+          skippingSSLCertificate ?? this.skippingSSLCertificate,
+      interceptor: interceptor ?? this.interceptor,
+      onRefreshToken: onRefreshToken ?? this.onRefreshToken,
+      onResponseParse: onResponseParse ?? this.onResponseParse,
+      maxRetryCount: maxRetryCount ?? this.maxRetryCount,
+      handleRefreshToken: handleRefreshToken ?? this.handleRefreshToken,
+    );
+  }
 
   @override
-  List<Object> get props => [baseOptions];
+  List<Object> get props => [baseOptions, handleRefreshToken];
 }

--- a/lib/src/model/index.dart
+++ b/lib/src/model/index.dart
@@ -2,4 +2,5 @@ export 'empty_model.dart';
 export 'error_model.dart';
 export 'local_data.dart';
 export 'network_result.dart';
+export 'request_flag.dart';
 export 'response_model.dart';

--- a/lib/src/model/request_flag.dart
+++ b/lib/src/model/request_flag.dart
@@ -1,0 +1,63 @@
+/// Request behavior flags for controlling specific NetworkManager features.
+///
+/// These flags provide a type-safe way to control various aspects of
+/// network requests without relying on magic strings in the extra map.
+///
+/// Example:
+/// ```dart
+/// // Disable refresh token for a specific request
+/// networkManager.send(
+///   '/api/login',
+///   parseModel: LoginModel(),
+///   method: RequestType.POST,
+///   requestFlags: {RequestFlag.disableRefreshToken},
+/// );
+/// ```
+enum RequestFlag {
+  /// Disables automatic refresh token handling for this request.
+  ///
+  /// When this flag is set, the NetworkManager will not attempt to
+  /// refresh the authentication token if the request fails with a 401
+  /// status code. The error will be returned immediately.
+  ///
+  /// Use this flag for:
+  /// - Login requests where refresh token doesn't make sense
+  /// - Logout requests to prevent infinite loops
+  /// - Public API calls that don't require authentication
+  /// - One-time authentication flows
+  disableRefreshToken,
+}
+
+/// Extension methods for RequestFlag enum to provide utility functions.
+extension RequestFlagExtension on Set<RequestFlag> {
+  /// Checks if the set contains the disableRefreshToken flag.
+  bool get shouldDisableRefreshToken =>
+      contains(RequestFlag.disableRefreshToken);
+
+  /// Converts the flags to a map for storing in Dio's extra field.
+  ///
+  /// This method is used internally by NetworkManager to convert
+  /// the type-safe flags into a format that can be stored in
+  /// Dio's RequestOptions.extra map.
+  Map<String, bool> toExtraMap() {
+    return {
+      for (final flag in this) '_flag_${flag.name}': true,
+    };
+  }
+
+  /// Creates a RequestFlag set from a Dio extra map.
+  ///
+  /// This method is used internally by NetworkManager to convert
+  /// the extra map back into type-safe RequestFlag values.
+  static Set<RequestFlag> fromExtraMap(Map<String, dynamic>? extra) {
+    if (extra == null) return <RequestFlag>{};
+
+    final flags = <RequestFlag>{};
+    for (final flag in RequestFlag.values) {
+      if (extra['_flag_${flag.name}'] == true) {
+        flags.add(flag);
+      }
+    }
+    return flags;
+  }
+}

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -97,12 +97,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     final defaultOptions = Options();
     options ??= defaultOptions;
     options.method = method.stringValue;
-    if (disableRefreshToken != null) {
-      final currentExtra =
-          options.extra == null ? <String, dynamic>{} : Map.of(options.extra!);
-      currentExtra['disableRefreshToken'] = disableRefreshToken;
-      options.extra = currentExtra;
-    }
+    _addDisableRefreshTokenFlag(options, disableRefreshToken);
     final body = makeRequestBodyData(data);
 
     try {

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -9,7 +9,6 @@ import 'package:vexana/src/feature/ssl/io_custom_override.dart'
     if (dart.library.html) 'package:vexana/src/feature/ssl/html_custom_override.dart'
     as ssl;
 import 'package:vexana/src/mixin/index.dart';
-import 'package:vexana/src/model/request_flag.dart';
 import 'package:vexana/src/utility/extension/request_type_extension.dart';
 import 'package:vexana/src/utility/network_manager_util.dart';
 import 'package:vexana/vexana.dart';

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -43,7 +43,6 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     Interceptor? interceptor,
     OnReply? onReply,
     int maxRetryCount = 3,
-    bool? handleRefreshToken,
   }) {
     parameters = NetworkManagerParameters(
       options: options,
@@ -57,7 +56,6 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
       onRefreshFail: onRefreshFail,
       onResponseParse: onReply,
       maxRetryCount: maxRetryCount,
-      handleRefreshToken: handleRefreshToken,
     );
     _setup();
   }
@@ -77,11 +75,6 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
   @override
   dio.Interceptors get dioInterceptors => interceptors;
 
-  /// This method is used to update the parameters of the network manager.
-  void _updateParameters({bool? handleRefreshToken}) {
-    parameters = parameters.copyWith(handleRefreshToken: handleRefreshToken);
-  }
-
   @override
   Future<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R>(
     String path, {
@@ -95,9 +88,8 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     ProgressCallback? onReceiveProgress,
     bool isErrorDialog = false,
     CancelToken? cancelToken,
-    bool? handleRefreshToken,
+    bool? disableRefreshToken,
   }) async {
-    _updateParameters(handleRefreshToken: handleRefreshToken);
     final checkFormCache =
         await _checkCache<R, T>(expiration, method, parseModel);
     if (checkFormCache != null) return checkFormCache;
@@ -105,6 +97,12 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     final defaultOptions = Options();
     options ??= defaultOptions;
     options.method = method.stringValue;
+    if (disableRefreshToken != null) {
+      final currentExtra =
+          options.extra == null ? <String, dynamic>{} : Map.of(options.extra!);
+      currentExtra['disableRefreshToken'] = disableRefreshToken;
+      options.extra = currentExtra;
+    }
     final body = makeRequestBodyData(data);
 
     try {
@@ -159,6 +157,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     ProgressCallback? onReceiveProgress,
     bool isErrorDialog = false,
     CancelToken? cancelToken,
+    bool? disableRefreshToken,
   }) async {
     final verifyFormCache = await _verifyCache<R, T>(
       expiration,
@@ -170,6 +169,12 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     final defaultOptions = Options();
     options ??= defaultOptions;
     options.method = method.stringValue;
+    if (disableRefreshToken != null) {
+      final currentExtra =
+          options.extra == null ? <String, dynamic>{} : Map.of(options.extra!);
+      currentExtra['disableRefreshToken'] = disableRefreshToken;
+      options.extra = currentExtra;
+    }
     final body = makeRequestBodyData(data);
 
     try {

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -97,7 +97,12 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     final defaultOptions = Options();
     options ??= defaultOptions;
     options.method = method.stringValue;
-    _addDisableRefreshTokenFlag(options, disableRefreshToken);
+    if (disableRefreshToken != null) {
+      final currentExtra =
+          options.extra == null ? <String, dynamic>{} : Map.of(options.extra!);
+      currentExtra['disableRefreshToken'] = disableRefreshToken;
+      options.extra = currentExtra;
+    }
     final body = makeRequestBodyData(data);
 
     try {

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -43,6 +43,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     Interceptor? interceptor,
     OnReply? onReply,
     int maxRetryCount = 3,
+    bool? handleRefreshToken,
   }) {
     parameters = NetworkManagerParameters(
       options: options,
@@ -56,6 +57,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
       onRefreshFail: onRefreshFail,
       onResponseParse: onReply,
       maxRetryCount: maxRetryCount,
+      handleRefreshToken: handleRefreshToken,
     );
     _setup();
   }
@@ -75,6 +77,11 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
   @override
   dio.Interceptors get dioInterceptors => interceptors;
 
+  /// This method is used to update the parameters of the network manager.
+  void _updateParameters({bool? handleRefreshToken}) {
+    parameters.copyWith(handleRefreshToken: handleRefreshToken);
+  }
+
   @override
   Future<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R>(
     String path, {
@@ -88,7 +95,9 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     ProgressCallback? onReceiveProgress,
     bool isErrorDialog = false,
     CancelToken? cancelToken,
+    bool? handleRefreshToken,
   }) async {
+    _updateParameters(handleRefreshToken: handleRefreshToken);
     final checkFormCache =
         await _checkCache<R, T>(expiration, method, parseModel);
     if (checkFormCache != null) return checkFormCache;

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -79,7 +79,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
 
   /// This method is used to update the parameters of the network manager.
   void _updateParameters({bool? handleRefreshToken}) {
-    parameters.copyWith(handleRefreshToken: handleRefreshToken);
+    parameters = parameters.copyWith(handleRefreshToken: handleRefreshToken);
   }
 
   @override

--- a/lib/vexana.dart
+++ b/lib/vexana.dart
@@ -16,6 +16,7 @@ export 'src/model/empty_model.dart';
 export 'src/model/enum/request_type.dart';
 export 'src/model/error_model.dart';
 export 'src/model/network_result.dart';
+export 'src/model/request_flag.dart';
 export 'src/model/response_model.dart';
 // NETWORK
 export 'src/network_manager.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "72.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.3"
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "6.7.0"
   args:
     dependency: transitive
     description:
@@ -34,18 +34,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -74,18 +74,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -98,10 +98,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -154,10 +154,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -217,18 +217,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -257,18 +257,18 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3-main.0"
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -305,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -449,7 +449,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_gen:
     dependency: transitive
     description:
@@ -462,50 +462,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -571,5 +571,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/test/unit/network_manager_request_flag_test.dart
+++ b/test/unit/network_manager_request_flag_test.dart
@@ -1,0 +1,212 @@
+// ignore_for_file: avoid_print
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vexana/vexana.dart';
+
+import '../utils/utils.dart';
+
+void main() {
+  group('RequestFlag Tests', () {
+    late NetworkManager<EmptyModel> networkManager;
+    late int refreshTokenCallCount;
+
+    setUp(() async {
+      await startServer();
+      refreshTokenCallCount = 0;
+      
+      networkManager = NetworkManager<EmptyModel>(
+        options: BaseOptions(baseUrl: serverUrl.toString()),
+        isEnableTest: true,
+        maxRetryCount: 3,
+        onRefreshFail: () => print('onRefreshFail Triggered'),
+        onRefreshToken: (error, networkManager) async {
+          refreshTokenCallCount++;
+          print('Refresh token called. Count: $refreshTokenCallCount');
+          
+          // Simulate successful token refresh by adding new Authorization header
+          error.requestOptions.headers['Authorization'] = 'Bearer new_token_$refreshTokenCallCount';
+          
+          return error;
+        },
+      );
+    });
+
+    tearDown(() {
+      stopServer();
+    });
+
+    test('401 error without disableRefreshToken flag should trigger refresh token', () async {
+      // Make request without disableRefreshToken flag
+      final response = await networkManager.send<EmptyModel, EmptyModel>(
+        '/unAuthorized',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+      );
+
+      // Refresh token should be called
+      expect(refreshTokenCallCount, greaterThan(0));
+      
+      // Request should succeed after refresh
+      expect(response.data, isNotNull);
+      expect(response.error, isNull);
+      
+      print('Test passed: Refresh token was triggered $refreshTokenCallCount times');
+    });
+
+    test('401 error with disableRefreshToken flag should NOT trigger refresh token', () async {
+      // Make request with disableRefreshToken flag
+      final response = await networkManager.send<EmptyModel, EmptyModel>(
+        '/unAuthorized',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+        requestFlags: {RequestFlag.disableRefreshToken},
+      );
+
+      // Refresh token should NOT be called
+      expect(refreshTokenCallCount, equals(0));
+      
+      // Request should fail with 401 error
+      expect(response.data, isNull);
+      expect(response.error, isNotNull);
+      expect(response.error?.statusCode, equals(401));
+      
+      print('Test passed: Refresh token was NOT triggered, error status: ${response.error?.statusCode}');
+    });
+
+    test('Successful request with disableRefreshToken flag should work normally', () async {
+      // Make successful request with disableRefreshToken flag
+      final response = await networkManager.send<EmptyModel, EmptyModel>(
+        '/test',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+        requestFlags: {RequestFlag.disableRefreshToken},
+      );
+
+      // Refresh token should NOT be called (because request was successful)
+      expect(refreshTokenCallCount, equals(0));
+      
+      // Request should succeed
+      expect(response.data, isNotNull);
+      expect(response.error, isNull);
+      
+      print('Test passed: Successful request with disableRefreshToken flag worked normally');
+    });
+
+    test('Multiple requests with mixed flags should behave correctly', () async {
+      // Reset counter
+      refreshTokenCallCount = 0;
+      
+      // Make one request without flag (should trigger refresh)
+      final response1 = await networkManager.send<EmptyModel, EmptyModel>(
+        '/unAuthorized',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+      );
+      
+      final firstRefreshCount = refreshTokenCallCount;
+      
+      // Make another request with flag (should NOT trigger refresh)
+      final response2 = await networkManager.send<EmptyModel, EmptyModel>(
+        '/unAuthorized',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+        requestFlags: {RequestFlag.disableRefreshToken},
+      );
+
+      // First request should trigger refresh
+      expect(firstRefreshCount, greaterThan(0));
+      expect(response1.data, isNotNull);
+      expect(response1.error, isNull);
+      
+      // Second request should NOT trigger additional refresh calls
+      expect(refreshTokenCallCount, equals(firstRefreshCount));
+      expect(response2.data, isNull);
+      expect(response2.error, isNotNull);
+      expect(response2.error?.statusCode, equals(401));
+      
+      print('Test passed: Mixed flag behavior worked correctly. Total refresh calls: $refreshTokenCallCount');
+    });
+
+    test('sendRequest method should also respect disableRefreshToken flag', () async {
+      // Reset counter
+      refreshTokenCallCount = 0;
+      
+      // Make request using sendRequest method with disableRefreshToken flag
+      final response = await networkManager.sendRequest<EmptyModel, EmptyModel>(
+        '/unAuthorized',
+        parseModel: EmptyModel(),
+        method: RequestType.GET,
+        requestFlags: {RequestFlag.disableRefreshToken},
+      );
+
+      // Refresh token should NOT be called
+      expect(refreshTokenCallCount, equals(0));
+      
+      // Request should fail with 401 error
+      expect(response.isError, isTrue);
+      expect(response.isSuccess, isFalse);
+      
+      response.fold(
+        onSuccess: (data) {
+          fail('Expected error but got success');
+        },
+        onError: (error) {
+          expect(error.statusCode, equals(401));
+        },
+      );
+      
+      print('Test passed: sendRequest method with disableRefreshToken flag worked correctly');
+    });
+  });
+
+  group('RequestFlag Extension Tests', () {
+    test('RequestFlag set should correctly identify disableRefreshToken', () {
+      final flags1 = <RequestFlag>{RequestFlag.disableRefreshToken};
+      expect(flags1.shouldDisableRefreshToken, isTrue);
+      
+      final flags2 = <RequestFlag>{};
+      expect(flags2.shouldDisableRefreshToken, isFalse);
+      
+      print('Test passed: RequestFlag extension methods work correctly');
+    });
+
+    test('RequestFlag set should convert to and from extra map correctly', () {
+      final originalFlags = <RequestFlag>{RequestFlag.disableRefreshToken};
+      
+      // Convert to extra map
+      final extraMap = originalFlags.toExtraMap();
+      expect(extraMap, isNotEmpty);
+      expect(extraMap['_flag_disableRefreshToken'], isTrue);
+      
+      // Convert back from extra map
+      final convertedFlags = RequestFlagExtension.fromExtraMap(extraMap);
+      expect(convertedFlags, equals(originalFlags));
+      expect(convertedFlags.shouldDisableRefreshToken, isTrue);
+      
+      print('Test passed: RequestFlag conversion methods work correctly');
+    });
+
+    test('Empty RequestFlag set should handle conversion correctly', () {
+      final emptyFlags = <RequestFlag>{};
+      
+      // Convert to extra map
+      final extraMap = emptyFlags.toExtraMap();
+      expect(extraMap, isEmpty);
+      
+      // Convert back from extra map
+      final convertedFlags = RequestFlagExtension.fromExtraMap(extraMap);
+      expect(convertedFlags, isEmpty);
+      expect(convertedFlags.shouldDisableRefreshToken, isFalse);
+      
+      print('Test passed: Empty RequestFlag set conversion works correctly');
+    });
+
+    test('Null extra map should return empty RequestFlag set', () {
+      final convertedFlags = RequestFlagExtension.fromExtraMap(null);
+      expect(convertedFlags, isEmpty);
+      expect(convertedFlags.shouldDisableRefreshToken, isFalse);
+      
+      print('Test passed: Null extra map handling works correctly');
+    });
+  });
+}

--- a/test/unit/network_manager_test.dart
+++ b/test/unit/network_manager_test.dart
@@ -67,7 +67,7 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
-    bool? disableRefreshToken,
+    Set<RequestFlag>? requestFlags,
   }) {
     return Future.value(ResponseModel(data: const EmptyModel() as R));
   }
@@ -100,7 +100,7 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
-    bool? disableRefreshToken,
+    Set<RequestFlag>? requestFlags,
   }) {
     return Future.value(NetworkSuccessResult(const EmptyModel() as R));
   }

--- a/test/unit/network_manager_test.dart
+++ b/test/unit/network_manager_test.dart
@@ -66,6 +66,7 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     data,
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
+    bool? handleRefreshToken,
     bool isErrorDialog = false,
   }) {
     return Future.value(ResponseModel(data: const EmptyModel() as R));

--- a/test/unit/network_manager_test.dart
+++ b/test/unit/network_manager_test.dart
@@ -66,8 +66,8 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     data,
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
-    bool? handleRefreshToken,
     bool isErrorDialog = false,
+    bool? disableRefreshToken,
   }) {
     return Future.value(ResponseModel(data: const EmptyModel() as R));
   }
@@ -100,6 +100,7 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
+    bool? disableRefreshToken,
   }) {
     return Future.value(NetworkSuccessResult(const EmptyModel() as R));
   }

--- a/test/utils/utils.dart
+++ b/test/utils/utils.dart
@@ -61,6 +61,12 @@ Future<void> startServer() async {
             await response.close();
             return;
           }(),
+        '/test' => () async {
+            response
+              ..statusCode = 200
+              ..write('success');
+            await response.close();
+          }(),
         '/redirect' => () async {
             response
               ..statusCode = 302


### PR DESCRIPTION
# RequestFlag System - Type-Safe Request Configuration

## Overview

The Vexana NetworkManager now supports a type-safe request configuration system using the `RequestFlag` enum, replacing magic strings in the extra map. This enhances code maintainability, IDE support, and prevents runtime errors caused by typos.

📌 **Related Issue:** [#129 - Add Optional Refresh Token Handling to `NetworkManager`](https://github.com/VB10/vexana/issues/129)

## RequestFlag Enum

The `RequestFlag` enum currently includes:

* `RequestFlag.disableRefreshToken`: Disables automatic refresh token handling for a specific request.

**Use cases:**

* Login/logout flows (prevent infinite loops)
* Public API calls without authentication
* One-off authentication flows

```dart
// Example: disable refresh token for the login endpoint
final result = await networkManager.send<LoginRequest, LoginResponse>(
  '/auth/login',
  parseModel: LoginResponse(),
  method: RequestType.POST,
  data: loginData,
  requestFlags: {RequestFlag.disableRefreshToken},
);
```

## Updated API Usage

Both `send` and `sendRequest` methods now accept an optional `requestFlags` parameter:

```dart
// send method
tFuture<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R>(
  String path, {
  required T parseModel,
  required RequestType method,
  // ... other parameters
  Set<RequestFlag>? requestFlags,
});

// sendRequest method
Future<NetworkResult<R, E>> sendRequest<T extends INetworkModel<T>, R>(
  String path, {
  required T parseModel,
  required RequestType method,
  // ... other parameters
  Set<RequestFlag>? requestFlags,
});
```

Additional utility extensions are available via `RequestFlagExtension`.

## Benefits

1. **Type Safety**: Compile-time checks prevent typos, IDE autocomplete support.
2. **Extensibility**: Easily add new flags, maintain backward compatibility.
3. **Developer Experience**: Self-documenting code, easy refactoring.
4. **Maintainability**: Eliminates scattered magic strings, centralizes flag definitions.

## Future Enhancements

Potential additional flags:

* `disableRetry`: Disable automatic retry mechanism
* `disableErrorDialog`: Disable error dialog display
* `disableCache`: Disable caching for specific requests
* `enableDebugLogging`: Enable detailed logging per request

## Best Practices

* Always use a `Set<RequestFlag>` for consistency.
* Document the reason for each flag use in comments.
* Avoid unnecessary flags to keep code clean.

```dart
// ✅ Good
requestFlags: {RequestFlag.disableRefreshToken}

// ❌ Avoid
requestFlags: [RequestFlag.disableRefreshToken].toSet()
```
