### PR TITLE
Enhancements to INetworkManager Interface and NetworkManager Class

### DIFF
--- a/example/lib/json_place_holder/json_place_holder_view_model.dart
+++ b/example/lib/json_place_holder/json_place_holder_view_model.dart
@@ -7,16 +7,21 @@ import 'model/post.dart';
 abstract class JsonPlaceHolderViewModel extends State<JsonPlaceHolder> {
   List<Post> posts = [];
 
-  late INetworkManager<Post> networkManager;
+  late INetworkManager<Post, String> networkManager;
 
   bool isLoading = false;
 
   @override
   void initState() {
     super.initState();
-    networkManager = NetworkManager<Post>(
+    networkManager = NetworkManager<Post, String>(
       isEnableLogger: true,
       // fileManager: LocalSembast(),
+      onRefreshToken: (error, newService) {
+        final param = newService.parameters.customParameter;
+        print(param);
+        return Future.value(error);
+      },
       isEnableTest: true,
       noNetwork: NoNetwork(
         context,
@@ -33,7 +38,7 @@ abstract class JsonPlaceHolderViewModel extends State<JsonPlaceHolder> {
 
   Future<void> getAllPosts() async {
     changeLoading();
-    final response = await networkManager.send<Post, List<Post>>(
+    final response = await networkManager.send<Post, List<Post>, String>(
       '/posts',
       parseModel: Post(),
       method: RequestType.GET,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   dio:
     dependency: transitive
     description:
@@ -124,18 +124,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -324,7 +324,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -337,10 +337,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -353,10 +353,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -395,15 +395,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.2"
+    version: "5.0.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -421,5 +421,5 @@ packages:
     source: hosted
     version: "1.0.4"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -3,18 +3,18 @@ import 'package:vexana/vexana.dart';
 
 /// The `INetworkManager` interface is used to define the methods that are used
 /// to send HTTP requests to a server. It extends the `NetworkManagerParameters`
-abstract class INetworkManager<E extends INetworkModel<E>>
-    with NetworkManagerOperation {
+abstract class INetworkManager<E extends INetworkModel<E>, P>
+    with NetworkManagerOperation<E, P> {
   /// [super.options] is a getter method that returns the `BaseOptions` object
   INetworkManager();
 
   /// [parameters] is a getter method that returns
   ///  the `NetworkManagerParameters`for detail
   @override
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   /// [cache] is a getter method that returns the `NetworkManagerCache`
-  NetworkManagerCache get cache;
+  NetworkManagerCache<E, P> get cache;
 
   /// The `Interceptors get dioInterceptors;` is a getter method that returns
   /// the interceptors used by the Dio HTTP client.
@@ -26,7 +26,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
   /// The `send` method is used to send an HTTP request to a specified
   /// `path` with various parameters. Here is a breakdown of
   /// the parameters:
-  Future<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R>(
+  Future<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R, O>(
     String path, {
     required T parseModel,
     required RequestType method,
@@ -39,6 +39,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     CancelToken? cancelToken,
     bool isErrorDialog = false,
     bool? handleRefreshToken,
+    O? customParameter,
   });
 
   /// The sendRequest method is used to send an HTTP request

--- a/lib/src/interface/i_network_manager.dart
+++ b/lib/src/interface/i_network_manager.dart
@@ -38,6 +38,7 @@ abstract class INetworkManager<E extends INetworkModel<E>>
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,
+    bool? handleRefreshToken,
   });
 
   /// The sendRequest method is used to send an HTTP request

--- a/lib/src/mixin/core/network_manager_initialize.dart
+++ b/lib/src/mixin/core/network_manager_initialize.dart
@@ -1,12 +1,10 @@
 part of '../../network_manager.dart';
 
 /// Network manager provide your requests with [Dio]
-mixin _NetworkManagerInitialize on DioMixin, NetworkManagerErrorInterceptor {
-  /// This method will be called when [NetworkManager] created
-  ///
-  ///   NetworkManagerParameters get parameters;
+mixin _NetworkManagerInitialize<E extends INetworkModel<E>, P>
+    on dio.DioMixin, NetworkManagerErrorInterceptor<E, P> {
   @override
-  NetworkManagerParameters get parameters;
+  late final NetworkManagerParameters<E, P> parameters;
 
   void _setup() {
     options = parameters.baseOptions;

--- a/lib/src/mixin/core/network_manager_initialize.dart
+++ b/lib/src/mixin/core/network_manager_initialize.dart
@@ -4,7 +4,8 @@ part of '../../network_manager.dart';
 mixin _NetworkManagerInitialize<E extends INetworkModel<E>, P>
     on dio.DioMixin, NetworkManagerErrorInterceptor<E, P> {
   @override
-  late final NetworkManagerParameters<E, P> parameters;
+  NetworkManagerParameters<E, P> parameters =
+      NetworkManagerParameters<E, P>(options: BaseOptions());
 
   void _setup() {
     options = parameters.baseOptions;

--- a/lib/src/mixin/network_manager_cache.dart
+++ b/lib/src/mixin/network_manager_cache.dart
@@ -8,10 +8,10 @@ import 'package:vexana/src/utility/network_manager_util.dart';
 import 'package:vexana/vexana.dart';
 
 /// Manage your data caching with [NetworkManagerCache]
-mixin NetworkManagerCache<E extends INetworkModel<E>>
-    on NetworkManagerResponse<E> {
+mixin NetworkManagerCache<E extends INetworkModel<E>, P>
+    on NetworkManagerResponse<E, P> {
   @override
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   String _urlKeyOnLocalData(RequestType type) =>
       '${parameters.baseOptions.baseUrl}-${type.stringValue}';

--- a/lib/src/mixin/network_manager_core_operation.dart
+++ b/lib/src/mixin/network_manager_core_operation.dart
@@ -2,14 +2,14 @@ import 'package:vexana/src/mixin/network_manager_parameters.dart';
 import 'package:vexana/vexana.dart';
 
 /// Manage network error situation
-mixin NetworkManagerCoreOperation<E extends INetworkModel<E>> {
+mixin NetworkManagerCoreOperation<E extends INetworkModel<E>, P> {
   int _noNetworkTryCount = 0;
 
   /// Network manager parameters
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   /// E: Error Model for generic error
-  INetworkManager<E> get instance;
+  INetworkManager<E, P> get instance;
 
   /// Manage any error according from server
   ///
@@ -17,7 +17,7 @@ mixin NetworkManagerCoreOperation<E extends INetworkModel<E>> {
   /// T: Parser Model
   /// data: Response body
   Future<IResponseModel<R?, E?>>
-      handleNetworkError<T extends INetworkModel<T>, R>({
+      handleNetworkError<T extends INetworkModel<T>, R, O>({
     required String path,
     required T parseModel,
     required RequestType method,
@@ -51,7 +51,7 @@ mixin NetworkManagerCoreOperation<E extends INetworkModel<E>> {
     if (isRetry) {
       _noNetworkTryCount = _noNetworkTryCount + 1;
 
-      return instance.send(
+      return instance.send<T, R, O>(
         path,
         parseModel: parseModel,
         method: method,

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -31,8 +31,8 @@ mixin NetworkManagerErrorInterceptor {
           return handler.next(exception);
         }
 
-        /// If callback for onRefreshToken is null, then return error
-        if (parameters.onRefreshToken == null) {
+        /// If handleRefreshToken is false, then return error
+        if (!parameters.handleRefreshToken) {
           return handler.next(exception);
         }
 
@@ -86,6 +86,7 @@ mixin NetworkManagerErrorInterceptor {
         isEnableTest: params.isEnableTest,
         options: parameters.baseOptions,
         maxRetryCount: params.maxRetryCount,
+        handleRefreshToken: params.handleRefreshToken,
       ),
     );
   }

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -5,12 +5,12 @@ import 'package:vexana/src/mixin/index.dart';
 import 'package:vexana/vexana.dart';
 
 /// Network manager error interceptor
-mixin NetworkManagerErrorInterceptor {
+mixin NetworkManagerErrorInterceptor<E extends INetworkModel<E>, P> {
   /// Network manager interceptors
   Interceptors get interceptors;
 
   /// Network manager base request options
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   /// Add your custom network interceptor
   void addNetworkInterceptors(Interceptor? interceptor) {
@@ -74,14 +74,14 @@ mixin NetworkManagerErrorInterceptor {
   /// It's retried if [exception] is [DioException] and status code is
   /// [HttpStatus.unauthorized].
   Future<DioException> _createError(
-    NetworkManagerParameters params,
+    NetworkManagerParameters<E, P> params,
     DioException exception,
   ) async {
     final error = _parallelismGuard(params, exception);
     if (error != null) return error;
     return params.onRefreshToken!(
       exception,
-      NetworkManager<EmptyModel>(
+      NetworkManager<E, P>(
         isEnableLogger: params.isEnableLogger,
         isEnableTest: params.isEnableTest,
         options: parameters.baseOptions,
@@ -134,7 +134,7 @@ mixin NetworkManagerErrorInterceptor {
   /// It's required to prevent parallel requests from being sent
   ///  to refresh token.
   DioException? _parallelismGuard(
-    NetworkManagerParameters params,
+    NetworkManagerParameters<E, P> params,
     DioException exception,
   ) {
     final cancelToken = exception.requestOptions.cancelToken;

--- a/lib/src/mixin/network_manager_error_interceptor.dart
+++ b/lib/src/mixin/network_manager_error_interceptor.dart
@@ -89,6 +89,7 @@ mixin NetworkManagerErrorInterceptor<E extends INetworkModel<E>, P> {
         options: parameters.baseOptions,
         maxRetryCount: params.maxRetryCount,
         handleRefreshToken: params.handleRefreshToken,
+        customParameter: params.customParameter,
       ),
     );
   }

--- a/lib/src/mixin/network_manager_header.dart
+++ b/lib/src/mixin/network_manager_header.dart
@@ -1,9 +1,10 @@
 import 'package:vexana/src/mixin/network_manager_parameters.dart';
+import 'package:vexana/vexana.dart';
 
 /// Network manager operation
-mixin NetworkManagerOperation {
+mixin NetworkManagerOperation<E extends INetworkModel<E>, P> {
   /// Network manager parameters
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   /// This method will add your [MapEntry] to header
   void addBaseHeader(MapEntry<String, String> mapEntry) {

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -14,7 +14,7 @@ typedef OnReply = Response<dynamic> Function(
 );
 
 @immutable
-class NetworkManagerParameters<E extends INetworkModel<E>, P extends Object?>
+class NetworkManagerParameters<E extends INetworkModel<E>, P>
     extends Equatable {
   final VoidCallback? onRefreshFail;
 

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -3,9 +3,10 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vexana/vexana.dart';
 
-typedef RefreshTokenCallBack = Future<DioException> Function(
+typedef RefreshTokenCallBack<E extends INetworkModel<E>, P>
+    = Future<DioException> Function(
   DioException error,
-  NetworkManager newService,
+  NetworkManager<E, P> newService,
 );
 
 typedef OnReply = Response<dynamic> Function(
@@ -13,7 +14,8 @@ typedef OnReply = Response<dynamic> Function(
 );
 
 @immutable
-class NetworkManagerParameters extends Equatable {
+class NetworkManagerParameters<E extends INetworkModel<E>, P extends Object?>
+    extends Equatable {
   final VoidCallback? onRefreshFail;
 
   final IFileManager? fileManager;
@@ -32,13 +34,15 @@ class NetworkManagerParameters extends Equatable {
 
   final BaseOptions baseOptions;
 
-  final RefreshTokenCallBack? onRefreshToken;
+  final RefreshTokenCallBack<E, P>? onRefreshToken;
 
   final OnReply? onResponseParse;
 
   final int maxRetryCount;
 
   final bool handleRefreshToken;
+
+  final P? customParameter;
 
   const NetworkManagerParameters({
     required BaseOptions options,
@@ -54,6 +58,7 @@ class NetworkManagerParameters extends Equatable {
     this.onResponseParse,
     this.maxRetryCount = 3,
     bool? handleRefreshToken,
+    this.customParameter,
   })  : assert(
           handleRefreshToken != true || onRefreshToken != null,
           'handleRefreshToken cannot be true if onRefreshToken is null',
@@ -61,7 +66,7 @@ class NetworkManagerParameters extends Equatable {
         baseOptions = options,
         handleRefreshToken = handleRefreshToken ?? onRefreshToken != null;
 
-  NetworkManagerParameters copyWith({
+  NetworkManagerParameters<E, P> copyWith({
     VoidCallback? onRefreshFail,
     IFileManager? fileManager,
     bool? isEnableTest,
@@ -71,12 +76,13 @@ class NetworkManagerParameters extends Equatable {
     bool? skippingSSLCertificate,
     Interceptor? interceptor,
     BaseOptions? baseOptions,
-    RefreshTokenCallBack? onRefreshToken,
+    RefreshTokenCallBack<E, P>? onRefreshToken,
     OnReply? onResponseParse,
     int? maxRetryCount,
     bool? handleRefreshToken,
+    P? customParameter,
   }) {
-    return NetworkManagerParameters(
+    return NetworkManagerParameters<E, P>(
       options: baseOptions ?? this.baseOptions,
       onRefreshFail: onRefreshFail ?? this.onRefreshFail,
       fileManager: fileManager ?? this.fileManager,
@@ -91,9 +97,10 @@ class NetworkManagerParameters extends Equatable {
       onResponseParse: onResponseParse ?? this.onResponseParse,
       maxRetryCount: maxRetryCount ?? this.maxRetryCount,
       handleRefreshToken: handleRefreshToken ?? this.handleRefreshToken,
+      customParameter: customParameter ?? this.customParameter,
     );
   }
 
   @override
-  List<Object> get props => [baseOptions, handleRefreshToken];
+  List<Object?> get props => [baseOptions, handleRefreshToken, customParameter];
 }

--- a/lib/src/mixin/network_manager_parameters.dart
+++ b/lib/src/mixin/network_manager_parameters.dart
@@ -38,6 +38,8 @@ class NetworkManagerParameters extends Equatable {
 
   final int maxRetryCount;
 
+  final bool handleRefreshToken;
+
   const NetworkManagerParameters({
     required BaseOptions options,
     this.onRefreshFail,
@@ -51,8 +53,47 @@ class NetworkManagerParameters extends Equatable {
     this.onRefreshToken,
     this.onResponseParse,
     this.maxRetryCount = 3,
-  }) : baseOptions = options;
+    bool? handleRefreshToken,
+  })  : assert(
+          handleRefreshToken != true || onRefreshToken != null,
+          'handleRefreshToken cannot be true if onRefreshToken is null',
+        ),
+        baseOptions = options,
+        handleRefreshToken = handleRefreshToken ?? onRefreshToken != null;
+
+  NetworkManagerParameters copyWith({
+    VoidCallback? onRefreshFail,
+    IFileManager? fileManager,
+    bool? isEnableTest,
+    bool? isEnableLogger,
+    NoNetwork? noNetwork,
+    int? noNetworkTryCount,
+    bool? skippingSSLCertificate,
+    Interceptor? interceptor,
+    BaseOptions? baseOptions,
+    RefreshTokenCallBack? onRefreshToken,
+    OnReply? onResponseParse,
+    int? maxRetryCount,
+    bool? handleRefreshToken,
+  }) {
+    return NetworkManagerParameters(
+      options: baseOptions ?? this.baseOptions,
+      onRefreshFail: onRefreshFail ?? this.onRefreshFail,
+      fileManager: fileManager ?? this.fileManager,
+      isEnableTest: isEnableTest ?? this.isEnableTest,
+      isEnableLogger: isEnableLogger ?? this.isEnableLogger,
+      noNetwork: noNetwork ?? this.noNetwork,
+      noNetworkTryCount: noNetworkTryCount ?? this.noNetworkTryCount,
+      skippingSSLCertificate:
+          skippingSSLCertificate ?? this.skippingSSLCertificate,
+      interceptor: interceptor ?? this.interceptor,
+      onRefreshToken: onRefreshToken ?? this.onRefreshToken,
+      onResponseParse: onResponseParse ?? this.onResponseParse,
+      maxRetryCount: maxRetryCount ?? this.maxRetryCount,
+      handleRefreshToken: handleRefreshToken ?? this.handleRefreshToken,
+    );
+  }
 
   @override
-  List<Object> get props => [baseOptions];
+  List<Object> get props => [baseOptions, handleRefreshToken];
 }

--- a/lib/src/mixin/network_manager_response.dart
+++ b/lib/src/mixin/network_manager_response.dart
@@ -7,9 +7,9 @@ import 'package:vexana/src/utility/logger/log_items.dart';
 import 'package:vexana/vexana.dart';
 
 /// Parse response body for success and error
-mixin NetworkManagerResponse<E extends INetworkModel<E>> {
+mixin NetworkManagerResponse<E extends INetworkModel<E>, P> {
   /// Network manager parameters
-  NetworkManagerParameters get parameters;
+  NetworkManagerParameters<E, P> get parameters;
 
   /// E: Error Model for generic error
   E? get errorModel;

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -65,9 +65,6 @@ class NetworkManager<E extends INetworkModel<E>, P> extends dio.DioMixin
   }
 
   @override
-  late final NetworkManagerParameters<E, P> parameters;
-
-  @override
   INetworkManager<E, P> get instance => this;
 
   @override
@@ -79,7 +76,8 @@ class NetworkManager<E extends INetworkModel<E>, P> extends dio.DioMixin
   @override
   dio.Interceptors get dioInterceptors => interceptors;
 
-  /// This method is used to update the parameters of the network manager.
+  /// This method is used to update the
+  /// parameters of the network manager.
   void _updateParameters({
     bool? handleRefreshToken,
     P? customParameter,

--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -43,6 +43,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     Interceptor? interceptor,
     OnReply? onReply,
     int maxRetryCount = 3,
+    bool? handleRefreshToken,
   }) {
     parameters = NetworkManagerParameters(
       options: options,
@@ -56,6 +57,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
       onRefreshFail: onRefreshFail,
       onResponseParse: onReply,
       maxRetryCount: maxRetryCount,
+      handleRefreshToken: handleRefreshToken,
     );
     _setup();
   }
@@ -75,6 +77,11 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
   @override
   dio.Interceptors get dioInterceptors => interceptors;
 
+  /// This method is used to update the parameters of the network manager.
+  void _updateParameters({bool? handleRefreshToken}) {
+    parameters.copyWith(handleRefreshToken: handleRefreshToken);
+  }
+
   @override
   Future<IResponseModel<R?, E?>> send<T extends INetworkModel<T>, R>(
     String path, {
@@ -88,7 +95,9 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     ProgressCallback? onReceiveProgress,
     bool isErrorDialog = false,
     CancelToken? cancelToken,
+    bool? handleRefreshToken,
   }) async {
+    _updateParameters(handleRefreshToken: handleRefreshToken);
     final checkFormCache =
         await _checkCache<R, T>(expiration, method, parseModel);
     if (checkFormCache != null) return checkFormCache;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,23 +5,23 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "72.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.3"
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "6.7.0"
   args:
     dependency: transitive
     description:
@@ -34,18 +34,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   build:
     dependency: transitive
     description:
@@ -74,18 +74,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
@@ -98,10 +98,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -154,10 +154,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -217,18 +217,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -257,18 +257,18 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3-main.0"
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -281,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -305,10 +305,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -449,7 +449,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_gen:
     dependency: transitive
     description:
@@ -462,50 +462,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -534,10 +534,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -571,5 +571,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.22.0"

--- a/test/feature/authorize_test/non_auth_test.dart
+++ b/test/feature/authorize_test/non_auth_test.dart
@@ -3,9 +3,9 @@ import 'package:vexana/vexana.dart';
 
 // ignore: always_declare_return_types
 void main() {
-  late INetworkManager networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       isEnableTest: true,
       onRefreshToken: (error, newService) async {
@@ -28,21 +28,22 @@ void main() {
   });
 
   test('Retry Auth Test', () async {
-    await networkManager.send<EmptyModel, EmptyModel>(
+    await networkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/words.json',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
 
-    await networkManager.send<EmptyModel, EmptyModel>(
+    await networkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/words2.json',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
 
-    final response = await networkManager.send<EmptyModel, EmptyModel>(
+    final response =
+        await networkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/words2.json',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
 

--- a/test/feature/cache-test/cache_test.dart
+++ b/test/feature/cache-test/cache_test.dart
@@ -10,11 +10,11 @@ import 'mock_path.dart';
 
 // ignore: always_declare_return_types
 void main() {
-  late INetworkManager networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   setUp(() {
     SharedPreferences.setMockInitialValues({}); //set values here
     PathProviderPlatform.instance = MockPathProviderPlatform();
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       fileManager: LocalFile(),
       isEnableLogger: true,
       isEnableTest: true,
@@ -23,7 +23,7 @@ void main() {
   });
 
   test('Json Place Shared Test Holder Todos', () async {
-    await networkManager.send<Todo, List<Todo>>(
+    await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: Duration(seconds: 3),
@@ -33,7 +33,7 @@ void main() {
     await Future<void>.delayed(Duration(seconds: 2));
     await networkManager.cache.removeAll();
 
-    final response2 = await networkManager.send<Todo, List<Todo>>(
+    final response2 = await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: Duration(seconds: 3),
@@ -43,7 +43,7 @@ void main() {
   });
 
   test('Json Place Files Test Holder Todos', () async {
-    await networkManager.send<Todo, List<Todo>>(
+    await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: Duration(seconds: 3),
@@ -53,7 +53,7 @@ void main() {
     await Future<void>.delayed(Duration(seconds: 1));
     await networkManager.cache.removeAll();
 
-    final response2 = await networkManager.send<Todo, List<Todo>>(
+    final response2 = await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: Duration(seconds: 2),
@@ -64,14 +64,14 @@ void main() {
   });
 
   test('Json Place Sembast Database Test Holder Todos', () async {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       fileManager: LocalFile(),
       isEnableLogger: true,
       options: BaseOptions(baseUrl: 'https://jsonplaceholder.typicode.com/'),
       isEnableTest: true,
     );
 
-    await networkManager.send<Todo, List<Todo>>(
+    await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: const Duration(seconds: 3),
@@ -81,7 +81,7 @@ void main() {
     await Future<void>.delayed(const Duration(seconds: 1));
     await networkManager.cache.removeAll();
 
-    final response2 = await networkManager.send<Todo, List<Todo>>(
+    final response2 = await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
       parseModel: Todo(),
       expiration: const Duration(seconds: 2),

--- a/test/feature/dog/http_dog_test.dart
+++ b/test/feature/dog/http_dog_test.dart
@@ -3,9 +3,9 @@ import 'package:vexana/vexana.dart';
 
 // ignore: always_declare_return_types
 void main() {
-  late INetworkManager networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       isEnableTest: true,
       interceptor: InterceptorsWrapper(
@@ -20,9 +20,10 @@ void main() {
     );
   });
   test('Primitive Type', () async {
-    final response = await networkManager.send<EmptyModel, EmptyModel>(
+    final response =
+        await networkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/dogs/0/code.json',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
     expect(response.data, isNotNull);

--- a/test/feature/file-download/file_download_model.dart
+++ b/test/feature/file-download/file_download_model.dart
@@ -1,8 +1,6 @@
 import 'package:vexana/vexana.dart';
 
 class FileDownloadModel extends INetworkModel<FileDownloadModel> {
-  String? fileId;
-
   FileDownloadModel({this.fileId});
 
   FileDownloadModel.fromJson(Map<String, dynamic>? json) {
@@ -11,6 +9,7 @@ class FileDownloadModel extends INetworkModel<FileDownloadModel> {
     }
     fileId = json['fileId'] as String?;
   }
+  String? fileId;
 
   @override
   Map<String, Object> toJson() {

--- a/test/feature/file-download/file_download_test.dart
+++ b/test/feature/file-download/file_download_test.dart
@@ -7,9 +7,9 @@ import 'file_download_model.dart';
 
 // ignore: always_declare_return_types
 void main() {
-  late INetworkManager networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       isEnableTest: true,
       options: BaseOptions(baseUrl: 'https://pdfobject.com/pdf/'),

--- a/test/feature/json_place_holder/json_place_test.dart
+++ b/test/feature/json_place_holder/json_place_test.dart
@@ -6,19 +6,19 @@ import 'package:vexana/vexana.dart';
 import 'todo.dart';
 
 void main() {
-  late INetworkManager<EmptyModel> networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
 
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       options: BaseOptions(baseUrl: 'https://jsonplaceholder.typicode.com/'),
       isEnableTest: true,
     );
   });
   test('Json Place Holder Todos', () async {
-    final response = await networkManager.send<Todo, List<Todo>>(
+    final response = await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
-      parseModel: Todo(),
+      parseModel: const Todo(),
       method: RequestType.GET,
     );
 
@@ -26,9 +26,9 @@ void main() {
   });
 
   test('First value add to all every request headers.', () async {
-    final response = await networkManager.send<Todo, List<Todo>>(
+    final response = await networkManager.send<Todo, List<Todo>, EmptyModel>(
       '/todos',
-      parseModel: Todo(),
+      parseModel: const Todo(),
       method: RequestType.GET,
     );
 

--- a/test/feature/refresh-token/refresh_user_token_test.dart
+++ b/test/feature/refresh-token/refresh_user_token_test.dart
@@ -5,11 +5,11 @@ import 'user.dart';
 
 // ignore: always_declare_return_types
 void main() {
-  late INetworkManager<EmptyModel> networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   const isServiceOn = false;
 
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       isEnableTest: true,
       // onRefreshFail: () {  Navigate to login },
@@ -26,7 +26,7 @@ void main() {
   test('Json Place Holder Todos', () async {
     if (!isServiceOn) return;
 
-    final response = await networkManager.send<User, User>(
+    final response = await networkManager.send<User, User, EmptyModel>(
       '/user',
       parseModel: User(),
       method: RequestType.GET,

--- a/test/feature/reqres/req_res_test.dart
+++ b/test/feature/reqres/req_res_test.dart
@@ -4,9 +4,9 @@ import 'package:vexana/vexana.dart';
 import 'req_res_model.dart';
 
 void main() {
-  late INetworkManager<EmptyModel> networkManager;
+  late INetworkManager<EmptyModel, EmptyModel> networkManager;
   setUp(() {
-    networkManager = NetworkManager<EmptyModel>(
+    networkManager = NetworkManager<EmptyModel, EmptyModel>(
       isEnableLogger: true,
       options: BaseOptions(baseUrl: 'https://reqres.in/api'),
       isEnableTest: true,
@@ -15,7 +15,7 @@ void main() {
   test('Delay Request', () async {
     final cancelToken = CancelToken();
     await networkManager
-        .send<ReqResModel, ReqResModel>(
+        .send<ReqResModel, ReqResModel, EmptyModel>(
       '/users?delay=5',
       parseModel: ReqResModel(),
       method: RequestType.GET,
@@ -33,7 +33,8 @@ void main() {
   });
 
   test('error Request', () async {
-    final response = await networkManager.send<ReqResModel, ReqResModel>(
+    final response =
+        await networkManager.send<ReqResModel, ReqResModel, EmptyModel>(
       '/users/23',
       parseModel: ReqResModel(),
       method: RequestType.GET,

--- a/test/unit/common/mock_network_manager.dart
+++ b/test/unit/common/mock_network_manager.dart
@@ -5,7 +5,8 @@ import 'package:vexana/vexana.dart';
 
 import 'mock_parameters.dart';
 
-final class MockErrorNetworkManager extends NetworkManager<EmptyModel> {
+final class MockErrorNetworkManager
+    extends NetworkManager<EmptyModel, EmptyModel> {
   MockErrorNetworkManager()
       : super(
           options: MockNetworkManagerLocalParameters().baseOptions,
@@ -13,7 +14,8 @@ final class MockErrorNetworkManager extends NetworkManager<EmptyModel> {
         );
 }
 
-final class MockErrorCustomNetworkManager extends NetworkManager<EmptyModel> {
+final class MockErrorCustomNetworkManager
+    extends NetworkManager<EmptyModel, EmptyModel> {
   MockErrorCustomNetworkManager(String baseUrl, AsyncCallback onRefresh)
       : super(
           options: BaseOptions(baseUrl: baseUrl),

--- a/test/unit/common/mock_parameters.dart
+++ b/test/unit/common/mock_parameters.dart
@@ -3,7 +3,7 @@ import 'package:vexana/src/mixin/network_manager_parameters.dart';
 import 'package:vexana/vexana.dart';
 
 class MockNetworkManagerParameters extends Mock
-    implements NetworkManagerParameters {
+    implements NetworkManagerParameters<EmptyModel, EmptyModel> {
   @override
   bool? get isEnableLogger => true;
   @override
@@ -17,7 +17,7 @@ class MockNetworkManagerParameters extends Mock
 }
 
 class MockNetworkManagerLocalParameters extends Mock
-    implements NetworkManagerParameters {
+    implements NetworkManagerParameters<EmptyModel, EmptyModel> {
   @override
   final BaseOptions baseOptions = BaseOptions(
     baseUrl: 'http://127.0.0.1:62052',

--- a/test/unit/common/mock_response_parse.dart
+++ b/test/unit/common/mock_response_parse.dart
@@ -5,12 +5,13 @@ import 'package:vexana/vexana.dart';
 import './index.dart';
 
 final class NetworkManagerResponseParseTest extends Mock
-    with NetworkManagerResponse<EmptyModel>
+    with NetworkManagerResponse<EmptyModel, EmptyModel>
     implements MockNetworkManagerParameters {
-  INetworkManager<EmptyModel> get instance => MockNetworkManager();
+  INetworkManager<EmptyModel, EmptyModel> get instance => MockNetworkManager();
 
   @override
-  NetworkManagerParameters get parameters => MockNetworkManagerParameters();
+  NetworkManagerParameters<EmptyModel, EmptyModel> get parameters =>
+      MockNetworkManagerParameters();
   @override
   bool? get isEnableLogger => true;
 
@@ -18,7 +19,7 @@ final class NetworkManagerResponseParseTest extends Mock
   EmptyModel? get errorModel => const EmptyModel();
 }
 
-final class MockNetworkManager extends NetworkManager<EmptyModel> {
+final class MockNetworkManager extends NetworkManager<EmptyModel, EmptyModel> {
   MockNetworkManager()
       : super(
           options: MockNetworkManagerParameters().baseOptions,

--- a/test/unit/model/network_manager_paramater_test.dart
+++ b/test/unit/model/network_manager_paramater_test.dart
@@ -8,7 +8,7 @@ void main() {
   setUp(() {});
   test('Network Parameter is valid', () {
     final mockContext = MockBuildContext();
-    final manager = NetworkManagerParameters(
+    final manager = NetworkManagerParameters<EmptyModel, EmptyModel>(
       options: BaseOptions(),
       isEnableTest: true,
       isEnableLogger: true,

--- a/test/unit/network_manager_error_test.dart
+++ b/test/unit/network_manager_error_test.dart
@@ -16,9 +16,10 @@ void main() {
       () async => retryCount++,
     );
 
-    final response = await errorNetworkManager.send<EmptyModel, EmptyModel>(
+    final response =
+        await errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/unAuthorized',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
     stopServer();
@@ -37,21 +38,21 @@ void main() {
 
     final cancelToken = CancelToken();
     await Future.wait<void>([
-      errorNetworkManager.send<EmptyModel, EmptyModel>(
+      errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
         '/unAuthorized',
-        parseModel: EmptyModel(),
+        parseModel: const EmptyModel(),
         cancelToken: cancelToken,
         method: RequestType.GET,
       ),
-      errorNetworkManager.send<EmptyModel, EmptyModel>(
+      errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
         '/unAuthorized',
-        parseModel: EmptyModel(),
+        parseModel: const EmptyModel(),
         cancelToken: cancelToken,
         method: RequestType.GET,
       ),
-      errorNetworkManager.send<EmptyModel, EmptyModel>(
+      errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
         '/unAuthorized',
-        parseModel: EmptyModel(),
+        parseModel: const EmptyModel(),
         cancelToken: cancelToken,
         method: RequestType.GET,
       ),
@@ -68,9 +69,10 @@ void main() {
       serverUrl.toString(),
       () async => _Helpers._addTokenOnRefresh(errorNetworkManager),
     );
-    final response = await errorNetworkManager.send<EmptyModel, EmptyModel>(
+    final response =
+        await errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
       '/unAuthorized',
-      parseModel: EmptyModel(),
+      parseModel: const EmptyModel(),
       method: RequestType.GET,
     );
     stopServer();
@@ -87,19 +89,19 @@ void main() {
     final responses =
         await Future.wait<IResponseModel<EmptyModel?, EmptyModel?>>(
       [
-        errorNetworkManager.send<EmptyModel, EmptyModel>(
+        errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
           '/unAuthorized',
-          parseModel: EmptyModel(),
+          parseModel: const EmptyModel(),
           method: RequestType.GET,
         ),
-        errorNetworkManager.send<EmptyModel, EmptyModel>(
+        errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
           '/unAuthorized',
-          parseModel: EmptyModel(),
+          parseModel: const EmptyModel(),
           method: RequestType.GET,
         ),
-        errorNetworkManager.send<EmptyModel, EmptyModel>(
+        errorNetworkManager.send<EmptyModel, EmptyModel, EmptyModel>(
           '/unAuthorized',
-          parseModel: EmptyModel(),
+          parseModel: const EmptyModel(),
           method: RequestType.GET,
         ),
       ],
@@ -115,10 +117,11 @@ void main() {
 
 class _Helpers {
   static Future<void> _addTokenOnRefresh(
-      NetworkManager<EmptyModel> manager) async {
+    NetworkManager<EmptyModel, EmptyModel> manager,
+  ) async {
     manager.options.headers.addEntries(
       [
-        const MapEntry('Authorization', "New Token"),
+        const MapEntry('Authorization', 'New Token'),
       ],
     );
   }

--- a/test/unit/network_manager_header_test.dart
+++ b/test/unit/network_manager_header_test.dart
@@ -1,11 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vexana/src/mixin/index.dart';
+import 'package:vexana/vexana.dart';
 
 import 'common/mock_parameters.dart';
 
-final class NetworkManagerHeaderTest with NetworkManagerOperation {
+final class NetworkManagerHeaderTest
+    with NetworkManagerOperation<EmptyModel, EmptyModel> {
   @override
-  final NetworkManagerParameters parameters = MockNetworkManagerParameters();
+  final NetworkManagerParameters<EmptyModel, EmptyModel> parameters =
+      MockNetworkManagerParameters();
 }
 
 void main() {

--- a/test/unit/network_manager_send_request_test.dart
+++ b/test/unit/network_manager_send_request_test.dart
@@ -4,7 +4,7 @@ import 'package:vexana/vexana.dart';
 import 'common/index.dart';
 
 void main() {
-  final INetworkManager manager = MockNetworkManager();
+  final INetworkManager<EmptyModel, EmptyModel> manager = MockNetworkManager();
 
   group('NetworkManager sendRequest tests', () {
     test('Success response parse - List', () async {

--- a/test/unit/network_manager_test.dart
+++ b/test/unit/network_manager_test.dart
@@ -20,9 +20,9 @@ void main() {
   });
 }
 
-class CustomNetworkManager extends INetworkManager<EmptyModel> {
+class CustomNetworkManager extends INetworkManager<EmptyModel, EmptyModel> {
   @override
-  NetworkManagerCache<INetworkModel<EmptyModel>> get cache =>
+  NetworkManagerCache<EmptyModel, EmptyModel> get cache =>
       throw UnimplementedError();
 
   @override
@@ -52,10 +52,12 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
   }
 
   @override
-  NetworkManagerParameters get parameters => throw UnimplementedError();
+  NetworkManagerParameters<EmptyModel, EmptyModel> get parameters =>
+      throw UnimplementedError();
 
   @override
-  Future<IResponseModel<R?, EmptyModel?>> send<T extends INetworkModel<T>, R>(
+  Future<IResponseModel<R?, EmptyModel?>>
+      send<T extends INetworkModel<T>, R, O>(
     String path, {
     required T parseModel,
     required RequestType method,
@@ -63,9 +65,10 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     Map<String, dynamic>? queryParameters,
     Options? options,
     Duration? expiration,
-    data,
+    dynamic data,
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
+    O? customParameter,
     bool? handleRefreshToken,
     bool isErrorDialog = false,
   }) {
@@ -96,7 +99,7 @@ class CustomNetworkManager extends INetworkManager<EmptyModel> {
     Map<String, dynamic>? queryParameters,
     Options? options,
     Duration? expiration,
-    data,
+    dynamic data,
     ProgressCallback? onReceiveProgress,
     CancelToken? cancelToken,
     bool isErrorDialog = false,


### PR DESCRIPTION
## Summary
This pull request introduces several changes and improvements to the Vexana library. Below is a summary of the modifications:

### Changes
- **INetworkManager Interface**: Updated to include a second generic parameter `P` for enhanced flexibility.
- **NetworkManager Class**: Refactored to support the new generic parameter `P` and added methods for handling custom parameters and refresh tokens.
- **Mixin Updates**:
  - Updated `NetworkManagerOperation`, `NetworkManagerCache`, `NetworkManagerResponse`, and other mixins to support the new generic parameter `P`.
  - Added support for custom parameters and improved error handling.
- **Tests**:
  - Updated all test cases to align with the new `INetworkManager` interface and `NetworkManager` class changes.
  - Added tests for custom parameter handling and refresh token logic.
- **Documentation**: Updated inline comments and documentation to reflect the new changes.

### Bug Fixes
- Fixed issues with caching logic in `NetworkManagerCache`.
- Resolved errors in `NetworkManagerErrorInterceptor` related to unauthorized requests.

### Breaking Changes
- The `INetworkManager` interface now requires two generic parameters.
- All usages of `NetworkManager` need to be updated to include the second generic parameter.

### Additional Notes
- Ensure to update your implementation to use the new `INetworkManager<E, P>` interface.
- Refer to the updated test cases for examples of the new usage.

## Checklist
- [x] Code changes are tested.
- [x] Documentation is updated.
- [x] Breaking changes are documented.