### PR TITLE
fix: stop removeAll from deleting the whole documents directory

### DIFF
--- a/lib/src/cache/file/file.dart
+++ b/lib/src/cache/file/file.dart
@@ -108,9 +108,22 @@ class _FileManager {
     );
   }
 
-  /// Remove old [Directory].
-  Future<void> clearAllDirectoryItems() async {
-    final tempDirectory = await documentsPath();
-    await tempDirectory.delete(recursive: true);
+  /// Remove cached entries whose key contains [url] from the cache file.
+  ///
+  /// Only the package's own cache file is touched; other files in the
+  /// documents directory are left as they are.
+  Future<void> clearCacheItems(String url) async {
+    final userDocumentFile = await getFile();
+    if (!userDocumentFile.existsSync()) return;
+    final tempDirectory = await fileReadAllData();
+    if (tempDirectory == null) {
+      await userDocumentFile.delete();
+      return;
+    }
+    tempDirectory.removeWhere((key, _) => key.contains(url));
+    await userDocumentFile.writeAsString(
+      jsonEncode(tempDirectory),
+      flush: true,
+    );
   }
 }

--- a/lib/src/cache/file/file.dart
+++ b/lib/src/cache/file/file.dart
@@ -108,7 +108,7 @@ class _FileManager {
     );
   }
 
-  /// Remove cached entries whose key contains [url] from the cache file.
+  /// Remove cached entries stored for the base [url] from the cache file.
   ///
   /// Only the package's own cache file is touched; other files in the
   /// documents directory are left as they are.
@@ -120,7 +120,7 @@ class _FileManager {
       await userDocumentFile.delete();
       return;
     }
-    tempDirectory.removeWhere((key, _) => key.contains(url));
+    tempDirectory.removeWhere((key, _) => key.startsWith('$url-'));
     await userDocumentFile.writeAsString(
       jsonEncode(tempDirectory),
       flush: true,

--- a/lib/src/cache/file/local_file_io.dart
+++ b/lib/src/cache/file/local_file_io.dart
@@ -44,23 +44,23 @@ class LocalFileIO extends IFileManager {
     if (time == null) {
       return false;
     } else {
-      final localModel =
-          LocalModel(model: model, time: DateTime.now().add(time));
+      final localModel = LocalModel(
+        model: model,
+        time: DateTime.now().add(time),
+      );
       await _fileManager.writeLocalModelInFile(key, localModel);
       return true;
     }
   }
 
   /// The `removeUserRequestCache()` method is responsible for removing
-  /// all user request
-  /// cache data. It calls the `_fileManager.clearAllDirectoryItems()`
-  ///  method to clear all
-  /// items in the cache directory. After clearing the cache, it returns
-  ///  `true` to indicate
-  /// that the operation was successful.
+  /// user request cache data whose key contains the given [key]. Only the
+  /// package's own cache file is modified; other files in the documents
+  /// directory are not touched. After clearing the cache, it returns
+  /// `true` to indicate that the operation was successful.
   @override
   Future<bool> removeUserRequestCache(String key) async {
-    await _fileManager.clearAllDirectoryItems();
+    await _fileManager.clearCacheItems(key);
     return true;
   }
 

--- a/lib/src/cache/file/local_file_io.dart
+++ b/lib/src/cache/file/local_file_io.dart
@@ -44,17 +44,15 @@ class LocalFileIO extends IFileManager {
     if (time == null) {
       return false;
     } else {
-      final localModel = LocalModel(
-        model: model,
-        time: DateTime.now().add(time),
-      );
+      final localModel =
+          LocalModel(model: model, time: DateTime.now().add(time));
       await _fileManager.writeLocalModelInFile(key, localModel);
       return true;
     }
   }
 
   /// The `removeUserRequestCache()` method is responsible for removing
-  /// user request cache data whose key contains the given [key]. Only the
+  /// user request cache data stored for the given base url [key]. Only the
   /// package's own cache file is modified; other files in the documents
   /// directory are not touched. After clearing the cache, it returns
   /// `true` to indicate that the operation was successful.

--- a/test/feature/cache-test/local_file_remove_test.dart
+++ b/test/feature/cache-test/local_file_remove_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vexana/vexana.dart';
+
+import '../json_place_holder/todo.dart';
+import 'mock_path.dart';
+
+void main() {
+  const body = '[{"userId":1,"id":1,"title":"cached","completed":true}]';
+  late Directory documents;
+  late HttpServer server;
+  late INetworkManager<EmptyModel> networkManager;
+
+  void serveTodos(HttpServer server) {
+    server.listen((request) async {
+      request.response
+        ..statusCode = 200
+        ..headers.contentType = ContentType('application', 'json')
+        ..write(body);
+      await request.response.close();
+    });
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    documents = await Directory.systemTemp.createTemp('vexana-cache-test-');
+    PathProviderPlatform.instance = _TestPathProviderPlatform(documents.path);
+    server = await HttpServer.bind('localhost', 0);
+    serveTodos(server);
+    networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      fileManager: LocalFile(),
+      options: BaseOptions(baseUrl: 'http://localhost:${server.port}'),
+    );
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+    if (documents.existsSync()) documents.deleteSync(recursive: true);
+  });
+
+  test('removeAll keeps unrelated files in the documents directory', () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final sentinel = File('${documents.path}/keep.txt')
+      ..writeAsStringSync('user data');
+
+    await networkManager.cache.removeAll();
+
+    expect(sentinel.existsSync(), isTrue);
+    expect(sentinel.readAsStringSync(), 'user data');
+  });
+
+  test(
+    'removeAll deletes a malformed cache file but keeps other files',
+    () async {
+      final cacheFile = File('${documents.path}/vexana.json')
+        ..writeAsStringSync('{not json');
+      final sentinel = File('${documents.path}/keep.txt')
+        ..writeAsStringSync('user data');
+
+      await networkManager.cache.removeAll();
+
+      expect(cacheFile.existsSync(), isFalse);
+      expect(sentinel.existsSync(), isTrue);
+      expect(sentinel.readAsStringSync(), 'user data');
+    },
+  );
+
+  test('removeAll clears only the entries of the given base url', () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final otherServer = await HttpServer.bind('localhost', 0);
+    addTearDown(() => otherServer.close(force: true));
+    serveTodos(otherServer);
+    final otherManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      fileManager: LocalFile(),
+      options: BaseOptions(baseUrl: 'http://localhost:${otherServer.port}'),
+    );
+    await otherManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+
+    await networkManager.cache.removeAll();
+
+    final cacheFile = File('${documents.path}/vexana.json');
+    expect(cacheFile.existsSync(), isTrue);
+    final content =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    expect(
+      content.keys.where(
+        (key) => key.contains('http://localhost:${server.port}'),
+      ),
+      isEmpty,
+    );
+    expect(
+      content.keys.where(
+        (key) => key.contains('http://localhost:${otherServer.port}'),
+      ),
+      isNotEmpty,
+    );
+  });
+}
+
+final class _TestPathProviderPlatform extends MockPathProviderPlatform {
+  _TestPathProviderPlatform(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String> getApplicationDocumentsPath() async => documentsPath;
+}

--- a/test/feature/cache-test/local_file_remove_test.dart
+++ b/test/feature/cache-test/local_file_remove_test.dart
@@ -116,6 +116,34 @@ void main() {
       isNotEmpty,
     );
   });
+
+  test('removeAll keeps a base url that merely extends the cleared one',
+      () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final cacheFile = File('${documents.path}/vexana.json');
+    final content =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    final extendedKey = 'http://localhost:${server.port}/v2-GET';
+    content[extendedKey] = content.values.first;
+    cacheFile.writeAsStringSync(jsonEncode(content));
+
+    await networkManager.cache.removeAll();
+
+    final remaining =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    expect(remaining.keys, contains(extendedKey));
+    expect(
+      remaining.keys.where(
+        (key) => key.startsWith('http://localhost:${server.port}-'),
+      ),
+      isEmpty,
+    );
+  });
 }
 
 final class _TestPathProviderPlatform extends MockPathProviderPlatform {


### PR DESCRIPTION
**Problem:** With the `LocalFile` manager, `cache.removeAll()` calls `_FileManager.clearAllDirectoryItems`, which deletes the application documents directory recursively. The cache lives in a single `vexana.json` file inside that directory, so everything else the app stored there is wiped as well. `LocalPreferences` behaves differently: it only removes the keys that contain the given base url.

**Solution:** Replace the directory deletion with `clearCacheItems(url)`, which rewrites `vexana.json` without the matching keys. If the file is malformed, delete only `vexana.json`. This aligns the two file managers on the same contract without touching sibling application files. Three regression tests cover sibling survival, preservation of another base URL, and malformed-cache cleanup.

Behavior note: `removeAll` used to wipe every cache entry regardless of the url argument; it now removes only the entries of the calling manager's base url, which is what `NetworkManagerCache.removeAll()` passes and what `LocalPreferences` already does.
