### PR TITLE
fix: implement download instead of recursing into itself

### DIFF
--- a/lib/src/network_manager.dart
+++ b/lib/src/network_manager.dart
@@ -272,7 +272,7 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
     dio.FileAccessMode fileAccessMode = dio.FileAccessMode.write,
     dio.Options? options,
   }) {
-    return this.download(
+    return clone().download(
       urlPath,
       savePath,
       onReceiveProgress: onReceiveProgress,
@@ -281,8 +281,8 @@ class NetworkManager<E extends INetworkModel<E>> extends dio.DioMixin
       deleteOnError: deleteOnError,
       lengthHeader: lengthHeader,
       data: data,
-      options: options,
       fileAccessMode: fileAccessMode,
+      options: options,
     );
   }
 

--- a/test/feature/download-test/download_test.dart
+++ b/test/feature/download-test/download_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vexana/vexana.dart';
+
+import '../../utils/utils.dart';
+
+void main() {
+  setUp(startServer);
+  tearDown(stopServer);
+
+  test('download writes the response body to the given path', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    final savePath = '${tempDirectory.path}/download.txt';
+    var interceptorCalled = false;
+    var progressCallCount = 0;
+    var lastReceived = 0;
+    networkManager.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          interceptorCalled = true;
+          handler.next(options);
+        },
+      ),
+    );
+
+    final response = await networkManager.download(
+      '/download',
+      savePath,
+      onReceiveProgress: (received, total) {
+        progressCallCount++;
+        lastReceived = received;
+      },
+    );
+
+    expect(response.statusCode, 200);
+    expect(File(savePath).readAsStringSync(), 'I am a text file');
+    expect(interceptorCalled, isTrue);
+    expect(progressCallCount, greaterThan(0));
+    expect(lastReceived, 'I am a text file'.length);
+  });
+
+  test('download resolves the save path from a callback', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+    await networkManager.download(
+      '/download',
+      (Headers headers) => '${tempDirectory.path}/from_headers.txt',
+    );
+
+    expect(
+      File('${tempDirectory.path}/from_headers.txt').readAsStringSync(),
+      'I am a text file',
+    );
+  });
+
+  test('download preserves removal of the implied content type', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    String? observedContentType;
+    networkManager.interceptors
+      ..removeImplyContentTypeInterceptor()
+      ..add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            observedContentType = options.contentType;
+            handler.next(options);
+          },
+        ),
+      );
+
+    await networkManager.download(
+      '/download',
+      '${tempDirectory.path}/without_implied_content_type.txt',
+      data: 'request body',
+    );
+
+    expect(observedContentType, isNull);
+  });
+}

--- a/test/feature/download-test/download_web_test.dart
+++ b/test/feature/download-test/download_web_test.dart
@@ -1,0 +1,54 @@
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vexana/vexana.dart';
+
+final class _ResponseAdapter implements HttpClientAdapter {
+  bool requestSeen = false;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestSeen = true;
+    return ResponseBody.fromString(
+      'hello',
+      200,
+      headers: {
+        Headers.contentLengthHeader: ['5'],
+        Headers.contentTypeHeader: ['text/plain'],
+      },
+    );
+  }
+}
+
+void main() {
+  test('download keeps dio web adapter unsupported behavior', () {
+    final adapter = _ResponseAdapter();
+    final manager = NetworkManager<EmptyModel>(
+      options: BaseOptions(baseUrl: 'https://example.test'),
+    )..httpClientAdapter = adapter;
+
+    expect(
+      () => manager.download('/download', 'probe.txt'),
+      throwsA(
+        isA<UnsupportedError>().having(
+          (error) => error.message,
+          'message',
+          'The download method is not available in the Web environment.',
+        ),
+      ),
+    );
+
+    expect(adapter.requestSeen, isFalse);
+  });
+}


### PR DESCRIPTION
**Problem:** `NetworkManager.download()` calls itself with the same arguments, so every call recurses until it throws `StackOverflowError`. Calling `super.download` is not a fallback because `DioMixin.download` throws `UnimplementedError`. The recursive override was added with the Dio 5.8.0 update in 5.0.3.

**Solution:** Delegate through Dio's platform-aware `clone()` path. It carries the manager's base options, exact interceptor chain, transformer and HTTP adapter without adding a second default content-type interceptor. Native downloads then use Dio's file, progress, cancellation and error handling. On web, this preserves the explicit `UnsupportedError` from the currently locked `dio_web_adapter` 2.1.0 instead of entering a `dart:io` path.

Three native regression tests use a local `HttpServer` to cover a string path, response content, progress callbacks, the manager's interceptor chain, preservation of an intentionally removed implied-content-type interceptor and a path callback based on response headers. A Chrome test covers the web boundary. The focused native tests pass 3/3, the Chrome test passes 1/1 and the full VM suite passes 44/44. `flutter analyze` reports only the repository's two existing info-level diagnostics. The example web build and its Wasm dry run also pass.

PR #132 currently touches the same override by calling `super.download`. Because `NetworkManager` extends `DioMixin`, that path is unimplemented; this focused change delegates to the concrete platform implementation and adds regression coverage.
