### PR TITLE
fix: removeAll'un tüm documents klasörünü silmesini engelle

### DIFF
--- a/packages/vexana/lib/src/cache/file/file.dart
+++ b/packages/vexana/lib/src/cache/file/file.dart
@@ -108,9 +108,22 @@ class _FileManager {
     );
   }
 
-  /// Remove old [Directory].
-  Future<void> clearAllDirectoryItems() async {
-    final tempDirectory = await documentsPath();
-    await tempDirectory.delete(recursive: true);
+  /// Remove cached entries stored for the base [url] from the cache file.
+  ///
+  /// Only the package's own cache file is touched; other files in the
+  /// documents directory are left as they are.
+  Future<void> clearCacheItems(String url) async {
+    final userDocumentFile = await getFile();
+    if (!userDocumentFile.existsSync()) return;
+    final tempDirectory = await fileReadAllData();
+    if (tempDirectory == null) {
+      await userDocumentFile.delete();
+      return;
+    }
+    tempDirectory.removeWhere((key, _) => key.startsWith('$url-'));
+    await userDocumentFile.writeAsString(
+      jsonEncode(tempDirectory),
+      flush: true,
+    );
   }
 }

--- a/packages/vexana/lib/src/cache/file/local_file_io.dart
+++ b/packages/vexana/lib/src/cache/file/local_file_io.dart
@@ -52,15 +52,13 @@ class LocalFileIO extends IFileManager {
   }
 
   /// The `removeUserRequestCache()` method is responsible for removing
-  /// all user request
-  /// cache data. It calls the `_fileManager.clearAllDirectoryItems()`
-  ///  method to clear all
-  /// items in the cache directory. After clearing the cache, it returns
-  ///  `true` to indicate
-  /// that the operation was successful.
+  /// user request cache data stored for the given base url [key]. Only the
+  /// package's own cache file is modified; other files in the documents
+  /// directory are not touched. After clearing the cache, it returns
+  /// `true` to indicate that the operation was successful.
   @override
   Future<bool> removeUserRequestCache(String key) async {
-    await _fileManager.clearAllDirectoryItems();
+    await _fileManager.clearCacheItems(key);
     return true;
   }
 

--- a/packages/vexana/test/feature/cache-test/local_file_remove_test.dart
+++ b/packages/vexana/test/feature/cache-test/local_file_remove_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:vexana/vexana.dart';
+
+import '../json_place_holder/todo.dart';
+import 'mock_path.dart';
+
+void main() {
+  const body = '[{"userId":1,"id":1,"title":"cached","completed":true}]';
+  late Directory documents;
+  late HttpServer server;
+  late INetworkManager<EmptyModel> networkManager;
+
+  void serveTodos(HttpServer server) {
+    server.listen((request) async {
+      request.response
+        ..statusCode = 200
+        ..headers.contentType = ContentType('application', 'json')
+        ..write(body);
+      await request.response.close();
+    });
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    documents = await Directory.systemTemp.createTemp('vexana-cache-test-');
+    PathProviderPlatform.instance = _TestPathProviderPlatform(documents.path);
+    server = await HttpServer.bind('localhost', 0);
+    serveTodos(server);
+    networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      fileManager: LocalFile(),
+      options: BaseOptions(baseUrl: 'http://localhost:${server.port}'),
+    );
+  });
+
+  tearDown(() async {
+    await server.close(force: true);
+    if (documents.existsSync()) documents.deleteSync(recursive: true);
+  });
+
+  test('removeAll keeps unrelated files in the documents directory', () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final sentinel = File('${documents.path}/keep.txt')
+      ..writeAsStringSync('user data');
+
+    await networkManager.cache.removeAll();
+
+    expect(sentinel.existsSync(), isTrue);
+    expect(sentinel.readAsStringSync(), 'user data');
+  });
+
+  test(
+    'removeAll deletes a malformed cache file but keeps other files',
+    () async {
+      final cacheFile = File('${documents.path}/vexana.json')
+        ..writeAsStringSync('{not json');
+      final sentinel = File('${documents.path}/keep.txt')
+        ..writeAsStringSync('user data');
+
+      await networkManager.cache.removeAll();
+
+      expect(cacheFile.existsSync(), isFalse);
+      expect(sentinel.existsSync(), isTrue);
+      expect(sentinel.readAsStringSync(), 'user data');
+    },
+  );
+
+  test('removeAll clears only the entries of the given base url', () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final otherServer = await HttpServer.bind('localhost', 0);
+    addTearDown(() => otherServer.close(force: true));
+    serveTodos(otherServer);
+    final otherManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      fileManager: LocalFile(),
+      options: BaseOptions(baseUrl: 'http://localhost:${otherServer.port}'),
+    );
+    await otherManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+
+    await networkManager.cache.removeAll();
+
+    final cacheFile = File('${documents.path}/vexana.json');
+    expect(cacheFile.existsSync(), isTrue);
+    final content =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    expect(
+      content.keys.where(
+        (key) => key.contains('http://localhost:${server.port}'),
+      ),
+      isEmpty,
+    );
+    expect(
+      content.keys.where(
+        (key) => key.contains('http://localhost:${otherServer.port}'),
+      ),
+      isNotEmpty,
+    );
+  });
+
+  test('removeAll keeps a base url that merely extends the cleared one',
+      () async {
+    await networkManager.send<Todo, List<Todo>>(
+      '/todos',
+      parseModel: const Todo(),
+      method: RequestType.GET,
+      expiration: const Duration(minutes: 5),
+    );
+    final cacheFile = File('${documents.path}/vexana.json');
+    final content =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    final extendedKey = 'http://localhost:${server.port}/v2-GET';
+    content[extendedKey] = content.values.first;
+    cacheFile.writeAsStringSync(jsonEncode(content));
+
+    await networkManager.cache.removeAll();
+
+    final remaining =
+        jsonDecode(cacheFile.readAsStringSync()) as Map<String, dynamic>;
+    expect(remaining.keys, contains(extendedKey));
+    expect(
+      remaining.keys.where(
+        (key) => key.startsWith('http://localhost:${server.port}-'),
+      ),
+      isEmpty,
+    );
+  });
+}
+
+final class _TestPathProviderPlatform extends MockPathProviderPlatform {
+  _TestPathProviderPlatform(this.documentsPath);
+
+  final String documentsPath;
+
+  @override
+  Future<String> getApplicationDocumentsPath() async => documentsPath;
+}


### PR DESCRIPTION
LocalFile yöneticisinde cache.removeAll(), _FileManager.clearAllDirectoryItems
üzerinden getApplicationDocumentsDirectory()'yi recursive siliyordu. Cache o
klasördeki tek bir vexana.json dosyasında yaşadığı hâlde, uygulamanın orada
tuttuğu her şey (veritabanları, indirilen dosyalar, kullanıcı verisi) birlikte
siliniyordu.

Artık clearCacheItems(url) ile vexana.json, eşleşen anahtarlar çıkarılarak
yeniden yazılıyor. Dosya bozuksa yalnızca vexana.json siliniyor. Kardeş
dosyalara dokunulmuyor.

Davranış değişikliği: removeAll eskiden url argümanından bağımsız olarak tüm
cache kayıtlarını siliyordu; artık yalnızca çağıran manager'ın baseUrl'ine ait
kayıtları siliyor. NetworkManagerCache.removeAll() zaten bunu geçiriyor ve
LocalPreferences de zaten böyle davranıyordu; iki dosya yöneticisi aynı
sözleşmeye getirildi.

PR #134 uyarlaması (melos yapısına taşındı).
Closes #134

Co-Authored-By: Yusuf İhsan Görgel <developeryusuf@icloud.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>