### PR TITLE
test: download için regresyon testleri ekle

### DIFF
--- a/packages/vexana/test/feature/download-test/download_test.dart
+++ b/packages/vexana/test/feature/download-test/download_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vexana/vexana.dart';
+
+import '../../utils/utils.dart';
+
+void main() {
+  setUp(startServer);
+  tearDown(stopServer);
+
+  test('download writes the response body to the given path', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    final savePath = '${tempDirectory.path}/download.txt';
+    var interceptorCalled = false;
+    var progressCallCount = 0;
+    var lastReceived = 0;
+    networkManager.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          interceptorCalled = true;
+          handler.next(options);
+        },
+      ),
+    );
+
+    final response = await networkManager.download(
+      '/download',
+      savePath,
+      onReceiveProgress: (received, total) {
+        progressCallCount++;
+        lastReceived = received;
+      },
+    );
+
+    expect(response.statusCode, 200);
+    expect(File(savePath).readAsStringSync(), 'I am a text file');
+    expect(interceptorCalled, isTrue);
+    expect(progressCallCount, greaterThan(0));
+    expect(lastReceived, 'I am a text file'.length);
+  });
+
+  test('download resolves the save path from a callback', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+    await networkManager.download(
+      '/download',
+      (Headers headers) => '${tempDirectory.path}/from_headers.txt',
+    );
+
+    expect(
+      File('${tempDirectory.path}/from_headers.txt').readAsStringSync(),
+      'I am a text file',
+    );
+  });
+
+  test('download preserves removal of the implied content type', () async {
+    final networkManager = NetworkManager<EmptyModel>(
+      isEnableTest: true,
+      options: BaseOptions(baseUrl: serverUrl.toString()),
+    );
+    final tempDirectory =
+        Directory.systemTemp.createTempSync('vexana_download_test');
+    addTearDown(() => tempDirectory.deleteSync(recursive: true));
+    String? observedContentType;
+    networkManager.interceptors
+      ..removeImplyContentTypeInterceptor()
+      ..add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            observedContentType = options.contentType;
+            handler.next(options);
+          },
+        ),
+      );
+
+    await networkManager.download(
+      '/download',
+      '${tempDirectory.path}/without_implied_content_type.txt',
+      data: 'request body',
+    );
+
+    expect(observedContentType, isNull);
+  });
+}

--- a/packages/vexana/test/feature/download-test/download_web_test.dart
+++ b/packages/vexana/test/feature/download-test/download_web_test.dart
@@ -1,0 +1,79 @@
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vexana/vexana.dart';
+
+/// `download`'ın web sınırındaki davranışı.
+///
+/// Bu testler PR #135'ten alındı; oradaki hâli `dio_web_adapter` 2.1.0'a göre
+/// yazılmıştı ve web'de `download`'ın `UnsupportedError` fırlatmasını
+/// bekliyordu. Paket 2.2.1'den itibaren web indirmesini gerçekten uyguluyor
+/// (yanıtı getirip tarayıcı indirmesini tetikliyor); yalnızca
+/// `FileAccessMode.append` desteklenmiyor. Testler güncel davranışa göre
+/// yeniden yazıldı.
+final class _ResponseAdapter implements HttpClientAdapter {
+  bool requestSeen = false;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestSeen = true;
+    return ResponseBody.fromString(
+      'hello',
+      200,
+      headers: {
+        Headers.contentLengthHeader: ['5'],
+        Headers.contentTypeHeader: ['text/plain'],
+      },
+    );
+  }
+}
+
+NetworkManager<EmptyModel> _managerWith(_ResponseAdapter adapter) {
+  return NetworkManager<EmptyModel>(
+    options: BaseOptions(baseUrl: 'https://example.test'),
+  )..httpClientAdapter = adapter;
+}
+
+void main() {
+  test('download web tarafında manager adapter\'ını kullanır', () async {
+    final adapter = _ResponseAdapter();
+
+    final response = await _managerWith(adapter).download(
+      '/download',
+      'probe.txt',
+    );
+
+    expect(
+      adapter.requestSeen,
+      isTrue,
+      reason: 'Delege manager.httpClientAdapter ile kurulmalı',
+    );
+    expect(response.data, 'hello'.codeUnits);
+  });
+
+  test('append modu web\'de desteklenmez ve isteğe hiç çıkılmaz', () async {
+    final adapter = _ResponseAdapter();
+
+    await expectLater(
+      _managerWith(adapter).download(
+        '/download',
+        'probe.txt',
+        fileAccessMode: FileAccessMode.append,
+      ),
+      throwsA(isA<UnsupportedError>()),
+    );
+
+    expect(adapter.requestSeen, isFalse);
+  });
+}


### PR DESCRIPTION
Native tarafta üç test: gövdenin verilen yola yazılması, save path'in
Headers callback'inden çözülmesi ve implied content-type interceptor'ının
kaldırılmış hâlinin korunması. Sonuncusu delegenin DioMixin.clone() ile
kurulmasını doğruluyor; elle Dio() kurulsaydı bu test kırmızı olurdu.

Web tarafında iki test: delegenin manager'ın adapter'ını kullanması ve
FileAccessMode.append'in desteklenmemesi. @TestOn('browser') ile
işaretli, VM suite'inde atlanıyor.

Testler PR #135'ten alındı. Web testi orada dio_web_adapter 2.1.0'a göre
yazılmış ve download'ın UnsupportedError fırlatmasını bekliyordu; paket
2.2.1'den beri web indirmesini gerçekten uyguluyor, bu yüzden test güncel
davranışa göre yeniden yazıldı. PR'ın implementasyon kısmı alınmadı:
özyineleme 305ead5'te düzeltilmiş, delege ise clone()'a geçirilmişti.

Refs #135

Co-Authored-By: Yusuf İhsan Görgel <developeryusuf@icloud.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>